### PR TITLE
Peer dependency fix

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -29,10 +29,6 @@ npm link troposphere-ui
 
 # Install guides dependencies
 npm i
-
-# Install library dependencies (the order here matters)
-cd ..
-npm i
 ```
 
 #### Build

--- a/guide/package.json
+++ b/guide/package.json
@@ -20,13 +20,9 @@
     "normalize.css": "^4.1.1",
     "radium": "^0.17.1",
     "react": "~15.1.0",
-    "react-collapse": "^2.2.4",
     "react-dom": "~15.1.0",
-    "react-height": "^2.1.0",
     "react-ink": "^5.1.1",
-    "react-motion": "^0.4.4",
     "react-scroll": "^1.0.17",
-    "tinycolor2": "^1.3.0",
     "troposphere-ui": "^0.*.*"
   },
   "devDependencies": {

--- a/guide/src/StyleGuide.js
+++ b/guide/src/StyleGuide.js
@@ -141,7 +141,7 @@ export default React.createClass({
             main: {
                 background: "whitesmoke",
                 width: "100%",
-                margin: "50px 0px 50px 250px", 
+                margin: "50px 0px 0px 250px", 
                 padding: "40px"
             },
         }

--- a/guide/webpack.config.js
+++ b/guide/webpack.config.js
@@ -18,8 +18,8 @@ module.exports = validate({
         new CleanPlugin(PATHS.dist)
     ],
     resolve: {
+        root: [__dirname + "/node_modules"],
         extensions: ["", ".js", ".jsx"],
-        fallback: __dirname + "/node_modules"
     },
     module: {
         loaders: [
@@ -30,7 +30,7 @@ module.exports = validate({
 
             {
                 test: /\.js$/,
-                include: /src/,
+                include: RegExp(__dirname + "/src"),
                 loaders:["react-hot", "babel-loader"]
             },
             {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "babel-cli": "^6.9.0",
     "babel-core": "^6.2.1",
     "babel-eslint": "^6.0.4",
-    "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-0": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,12 @@
   },
   "homepage": "https://github.com/cyverse/troposphere-ui#readme",
   "peerDependencies": {
+    "react": "^15.1.0"
+  },
+  "dependencies": {
     "radium": "^0.17.1",
-    "react": "^15.1.0",
     "react-collapse": "^2.2.4",
+    "react-height": "^2.1.1",
     "react-ink": "^5.1.1",
     "react-motion": "^0.4.4",
     "react-scroll": "^1.0.17",


### PR DESCRIPTION
I finally understand `peerDependencies`..  37d5853ace4402f422c5a2c7f5d0c1b017a9f334

```
When multiple packages need the the exact same instance of a library, simply
having separate copies will not do. For example, multiple instances of the
React library will stomp on one another, there can only be one instance.
Thus libraries that extend React cannot each include their own React, they
must express the need of sharing a specific instance. A peerDependency is this
request.
```

I figured out why the install process was brittle and how it was easy to install duplicate versions of react    https://github.com/cyverse/troposphere-ui/commit/9b5aeaf85ae1c3d453b31cc491975270b601e6b6

```
When webpack imports dependencies it will look in the local node_modules
folder. The library troposphere-ui imports react, so webpack looks in it that
libraries node_modules for that version of react. React is also imported from
the guide. So with webpack's simple module resolution multiple copies of react
get bundled. The webpack resolve root config will adjust the search path such
that the root paths are searched first, this way we can ensure that the
guide's version of react will always be preferred.
```

I also added a small css fix to the margins.
