### PR TITLE
move lib to root dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,17 @@
-# oh - the ignorez you'll see!
+# Ignore everything 
+*
+
+# Don't Ignore
+!package.json
+!.babel.rc
+!README.md
+!TODO.md
+
+!./src
+
+!./guide
+
+# Ignore temp files
 *.swp
 *.swo
 *.~
-
-# ignore all modules from npm
-node_modules
-
-# ignore compiled code
-lib
-
-# ignore npm fail log
-npm-debug.log

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "troposphere-ui",
   "version": "0.0.1",
   "description": "A UI library for Troposphere",
-  "main": "lib/index.js",
+  "main": "./index.js",
   "scripts": {
-    "build": "babel -d lib src",
-    "watch": "babel -w src -d lib"
+    "build": "babel -d ./ src",
+    "watch": "babel -w src -d ./"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Builds into the root dir and git ignores the build files so that that the library can be consumed preserving the namespace in src. 

For example `import { thing-1, thing-2 } from troposphere-ui/lib/things`
can now be  `import { thing-1, thing-2 } from troposphere-ui/things`
