### PR TITLE
Create MediaCardGroup and example

### DIFF
--- a/guide/src/ExampleList.js
+++ b/guide/src/ExampleList.js
@@ -4,6 +4,7 @@ import {
     ButtonEx,
     FlatButtonEx,
     MediaCardEx,
+    MediaCardGroupEx,
     AvatarEx,
     TooltipEx,
     TransitionEx,
@@ -234,6 +235,24 @@ const ExampleList = [
                 </P>
             </div>
         ),
+    },
+    {
+        name: "MediaCard",
+        desc: (
+            <P>
+                MediaCards are used for objects like Projects, Project Resources, and Images that have their own information and actions associated with them. They typically have a short description and a long description that can be seen by expanding the card. A contextual menu, attached to the card, contains all of the actions for that card.
+            </P>
+        ),
+        render: MediaCardEx,
+    },
+    {
+        name: "MediaCardGroup",
+        desc: (
+            <P>
+                Since only one MediaCard should be open at a time and clicking off the media card should close it a MediaCardGroup is used to control this interdependent behaviour.
+            </P>
+        ),
+        render: MediaCardGroupEx,
     },
 ];
 

--- a/guide/src/examples/index.js
+++ b/guide/src/examples/index.js
@@ -16,4 +16,5 @@ export { default as DialogEx } from './DialogEx'
 export { default as CheckboxEx } from './CheckboxEx'
 export { default as RadioButtonEx } from './RadioButtonEx'
 export { default as TagEx } from './TagEx'
+export { default as MediaCardGroupEx } from './MediaCardGroupEx'
 

--- a/guide/src/index.html
+++ b/guide/src/index.html
@@ -1,7 +1,7 @@
 <html> 
     <head>
         <meta charset="utf-8">
-        <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,300' rel='stylesheet' type='text/css'>
+        <!--link href='https://fonts.googleapis.com/css?family=Roboto:400,500,300' rel='stylesheet' type='text/css'-->
     </head>
     <body>
         <div id="app"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export { default as Hr } from './Hr';
 export { default as IconBase } from './IconBase';
 export { default as Loader } from './Loader';
 export { default as MediaCard } from './MediaCard';
+export { default as MediaCardGroup } from './MediaCardGroup';
 export { default as MeterGauge } from './MeterGauge';
 export { default as SelectMenu } from './SelectMenu';
 export { default as ShowMoreEllipsis } from './ShowMoreEllipsis';


### PR DESCRIPTION
## Adds a the MediaCardGroup component

Since MediaCards in a list have a interdependent behavior they are wrapped in the MediaCardGroup that handles the opening and closing state of the cards. 

At this point the only API are our margin props `mr, mb, etc...`.  However, a `current` prop could be added to have a given card scrolled into view and open, along with an `onTouch` callback that passes the card clicked. These could be handy in showing a card detail by URL and changing the URL by card clicked.

One could argue that if managing the URL is the only way we will use cards then we probably don't need this wrapper component at all. 

For now though, it hides all of the boilerplate from Troposhere if all we need is this basic functionality.  
#### Use

```
   <MediaCardGroup mb={ 4 }>
        <MediaCard
            title="Card 1"
            detail="sdsdsdsdsds"
            contextualMenu = {[
                {render: "red"},
                {render: "yellow"},
                {render: "green"}
            ]}
        />
        <MediaCard
            title="Card 2"
            detail="sdsdsdsdsds"
            contextualMenu = {[
                {render: "red"},
                {render: "yellow"},
                {render: "green"}
            ]}
        />
    </MediaCardGroup>
```

![mediacardgroup](https://cloud.githubusercontent.com/assets/7366338/18059334/62ec3710-6dcd-11e6-98a8-0d90bda3042f.gif)
