### PR TITLE
Gen random color from string

### DIFF
--- a/guide/src/examples/AvatarEx.js
+++ b/guide/src/examples/AvatarEx.js
@@ -17,7 +17,6 @@ export default React.createClass({
                         <Avatar
                             name="Megatron"
                             size={ 30 }
-                            color="#a9cc66"
                             mr={ 3 }
                         />
                         Megatron
@@ -31,7 +30,6 @@ export default React.createClass({
                         <Avatar
                             name="Cobra Commander"
                             size={ 40 }
-                            color="#87a8f0"
                             mr={ 3 }
                         />
                         Cobra Commander
@@ -44,7 +42,6 @@ export default React.createClass({
                         <Avatar
                             name="Skeletor"
                             size={ 50 }
-                            color="#29eded"
                             mr={ 3 }
                         />
                         Skelletor
@@ -64,7 +61,6 @@ export default React.createClass({
         <Avatar
             name="Megatron"
             size={ 30 }
-            color="#a9cc66"
             mr={ 3 }
         />
         Megatron
@@ -78,7 +74,6 @@ export default React.createClass({
         <Avatar
             name="Cobra Commander"
             size={ 40 }
-            color="#87a8f0"
             mr={ 3 }
         />
         Cobra Commander
@@ -91,7 +86,6 @@ export default React.createClass({
         <Avatar
             name="Skeletor"
             size={ 50 }
-            color="#29eded"
             mr={ 3 }
         />
         Skelletor

--- a/package.json
+++ b/package.json
@@ -21,15 +21,16 @@
     "react": "^15.1.0"
   },
   "dependencies": {
+    "material-ui": "~0.15.1",
     "radium": "^0.17.1",
+    "randomcolor": "^0.4.4",
     "react-collapse": "^2.2.4",
     "react-height": "^2.1.1",
     "react-ink": "^5.1.1",
     "react-motion": "^0.4.4",
     "react-scroll": "^1.0.17",
-    "tinycolor2": "^1.3.0",
-    "material-ui": "~0.15.1",
-    "react-tap-event-plugin": "~1.0.0"
+    "react-tap-event-plugin": "~1.0.0",
+    "tinycolor2": "^1.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import radium from 'radium';
 import tinyColor from 'tinycolor2';
+import randomcolor from 'randomcolor';
 import { marg } from './styles';
 
 const Avatar = React.createClass({
@@ -18,7 +19,9 @@ const Avatar = React.createClass({
 
     styles() {
         let size = this.props.size;
-        let color = this.props.color;
+        let color = randomcolor({
+          seed: this.props.name  
+        });
 
         return {
             display: "inline-block",


### PR DESCRIPTION
Sets the background color of the Avatar component to a random color generated by using the `name` prop as a seed. This gives a consistent color for a particular image every time. 

Two components with the same name will have the same color but this seems acceptable to me. A solution would be to have an optional `seed` prop that a UUID could be used instead but I don't think it is a problem to be solved.    
