### PR TITLE
Problem: font appearance within "guide" not as expected

### DIFF
--- a/guide/src/base.css
+++ b/guide/src/base.css
@@ -1,6 +1,6 @@
 * { box-sizing: border-box; }
-body { 
-    font-family: 'Roboto', sans-sarif;
+body {
+    font-family: 'Roboto', sans-serif;
     color: #212121;
 }
 

--- a/guide/src/index.html
+++ b/guide/src/index.html
@@ -1,7 +1,7 @@
-<html> 
+<html>
     <head>
-        <meta charset="utf-8">
-        <!--link href='https://fonts.googleapis.com/css?family=Roboto:400,500,300' rel='stylesheet' type='text/css'-->
+        <meta charset="utf-8" />
+        <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,300' rel='stylesheet' type='text/css' />
     </head>
     <body>
         <div id="app"></div>


### PR DESCRIPTION
## Description

While reviewing the rendering of the GitHub Pages view of the "guide", we noticed that there were two issue preventing the body font from being rendered correctly:
- the link to the Roboto web font had been commented out
- the "fallback" for the `font-family` contained a typo

The result was that the body text of the guide was rendered with a generic serif font.

I have not seen this captured with an issue nor has a pull request been made. 

<details>

## Shows Expected Font Family Rendering^^
![screen shot 2017-06-11 at 11 07 16 am](https://user-images.githubusercontent.com/5923/27013318-8ab1f0e6-4e96-11e7-80d0-8915a5aff484.png)

^^ _Note: this includes a forthcoming pull request that correct InterCaps usage_
</details>
