### PR TITLE
Problem: usage of CyVerse name does not match branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Cyverse UI
-A collection of UI components and live Style Guide that extends [Material-UI](https://github.com/callemall/material-ui) for use within the Cyverse ecosystem.
+# CyVerse UI
+A collection of UI components and live Style Guide that extends [Material-UI](https://github.com/callemall/material-ui) for use within the CyVerse ecosystem.
 
 View a demo [here](https://cyverse.github.io/cyverse-ui).
 

--- a/guide/package.json
+++ b/guide/package.json
@@ -10,7 +10,7 @@
     "build": "webpack",
     "serve": "webpack-dev-server --inline"
   },
-  "author": "Cyverse",
+  "author": "CyVerse",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/cyverse/cyverse-ui/issues"

--- a/guide/src/StyleGuide.js
+++ b/guide/src/StyleGuide.js
@@ -85,10 +85,10 @@ export default React.createClass({
                                 color={ theme.color.primary }
                                 mb={ 3 }
                             >
-                                Cyverse UI
+                                CyVerse UI
                             </Title>
                             <P subheading>
-                                A collection of UI components for Cyverse that extend <a href="http://www.material-ui.com/" target="_blank" title="Material-UI">Material-UI</a> adding components that handle UI patterns within the Cyverse ecosystem not covered by Material-UI.
+                                A collection of UI components for CyVerse that extend <a href="http://www.material-ui.com/" target="_blank" title="Material-UI">Material-UI</a> adding components that handle UI patterns within the CyVerse ecosystem not covered by Material-UI.
                             </P>
                         </Section>
                         <Section>

--- a/guide/src/ThemeExList.js
+++ b/guide/src/ThemeExList.js
@@ -7,25 +7,25 @@ import ThemeColorsEx from './examples/ThemeColorsEx';
 
 const ThemeExList = [
     {
-        name: "Cyverse Theme",
+        name: "CyVerse Theme",
         desc: (
             <div>
                 <P>
-                    The cyverseTheme is provided by the Cyverse-UI library and works with the Material-UI theme system to maintain a consistent "Cyverse look" across all applications using it.  
+                    The <code>cyverseTheme</code> is provided by the CyVerse-UI library and works with the Material-UI theme system to maintain a consistent "CyVerse look" across all applications using it.
                 </P>
 		<ThemeEx/>
             </div>
         ), 
     },
     {
-        name: "Cyverse Theme Colors",
+        name: "CyVerse Theme Colors",
         desc: (
             <div>
                 <P>
-                    The cyverseTheme colors are part of a color system, encouraging proper contrast and consistency while enforcing the Cyverse band.  
+                    The <code>cyverseTheme</code> colors are part of a color system, encouraging proper contrast and consistency while enforcing the CyVerse band.
                 </P>
                 <P>
-                    These colors can be overridden when initializing the Material-UI theme provider. See directions for this and installing the Cyverse theme below.	 
+                    These colors can be overridden when initializing the Material-UI theme provider. See directions for this and installing the CyVerse theme below.
                 </P>
                 <Paper style={{ padding: "20px" }}>
                     <ThemeColorsEx/>
@@ -34,11 +34,11 @@ const ThemeExList = [
         ), 
     },
     {
-        name: "Installing Cyverse Theme",
+        name: "Installing CyVerse Theme",
         desc: (
             <div>
                 <P>
-                    To use the Cyverse theme we need to wrap our entire application in the Material-UI theme provider (MuiThemeProvider) and initialize it with our custom Cyverse theme using "getMuiTheme" as our base theme. This will make the theme values available to all of the components. 
+                    To use the CyVerse theme we need to wrap our entire application in the Material-UI theme provider (MuiThemeProvider) and initialize it with our custom CyVerse theme using "getMuiTheme" as our base theme. This will make the theme values available to all of the components.
                 </P>
                 <Code>
                     {
@@ -62,14 +62,14 @@ ReactDOM.render(
                     }
                 </Code>
             </div>
-        ), 
+        ),
     },
     {
         name: "muiThemeable",
         desc: (
             <div>
                 <P>
-                    The cyverseTheme values can be used by your app specific components using Material-ui's "muiThemeable" module. To use export "muiThemeable" passing your component as a second argument.  The theme object will be available to your component through it's props. 
+                    The <code>cyverseTheme</code> values can be used by your app specific components using Material-ui's "muiThemeable" module. To use export "muiThemeable" passing your component as a second argument.  The theme object will be available to your component through it's props.
                 </P>
                 <Code>
                     {

--- a/guide/src/base.css
+++ b/guide/src/base.css
@@ -1,6 +1,6 @@
 * { box-sizing: border-box; }
-body { 
-    font-family: 'Roboto', sans-sarif;
+body {
+    font-family: 'Roboto', sans-serif;
     color: #212121;
 }
 

--- a/guide/src/index.html
+++ b/guide/src/index.html
@@ -1,7 +1,7 @@
-<html> 
+<html>
     <head>
-        <meta charset="utf-8">
-        <!--link href='https://fonts.googleapis.com/css?family=Roboto:400,500,300' rel='stylesheet' type='text/css'-->
+        <meta charset="utf-8" />
+        <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,300' rel='stylesheet' type='text/css' />
     </head>
     <body>
         <div id="app"></div>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "type": "git",
     "url": "git+https://github.com/cyverse/cyverse-ui.git"
   },
-  "author": "Cyverse",
+  "author": "CyVerse",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/cyverse/cyverse-ui/issues"

--- a/src/styles/README.md
+++ b/src/styles/README.md
@@ -22,8 +22,8 @@ The following properties will take a number 1-10 and return the correct styles f
 - pl = paddingRight
 - ps = paddingRight, PaddingLeft
 
-## Cyverse Theme
-We ship a Material-ui compatible theme `cyverseTheme.json` that can be used by consumers of this library to implement the Cyverse brand color pallete in their applications. 
+## CyVerse Theme
+We ship a Material-ui compatible theme `cyverseTheme.json` that can be used by consumers of this library to implement the CyVerse brand color pallete in their applications.
 
 Running `npm run build` will use the `makeTheme.js` script to generate `cyverseTheme.json` found in the styles directory. Or run manually `node makeTheme.js`.
 


### PR DESCRIPTION
## Description 

The _display_ usage of the name, CyVerse, within the Style Guide must incorporate the BiCapitalization. 

This depends on #33.

<details>

## Shows Expected InterCaps Appearance
![screen shot 2017-06-11 at 11 07 16 am](https://user-images.githubusercontent.com/5923/27013318-8ab1f0e6-4e96-11e7-80d0-8915a5aff484.png)

</details>