### PR TITLE
Avoid NPM ignoring sub-folders

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,8 @@
 
 # Don't ignore js in root dir
 !*.js
+
+# Don't ignore js within sub-folders
+!icons/*js
+!utils/*.js
+!styles/*.js


### PR DESCRIPTION
There does *not* appear to be an easy way to ignore multiple directories on one line of an .npmignore file. The .npmignore syntax is the same as that of .gitignore \[[0](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package)\]. In reviewing the latest `git` documentation \[[1](https://git-scm.com/docs/gitignore)\], it seems the only approach is just listing each individual directory.

\[0\] https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
\[1\] https://git-scm.com/docs/gitignore