### PR TITLE
Problem: React Tap Event plugin missing from dependencies

### DIFF
--- a/guide/package.json
+++ b/guide/package.json
@@ -25,7 +25,8 @@
     "react": "~15.4.0",
     "react-dom": "~15.4.0",
     "react-ink": "^5.1.1",
-    "react-scroll": "^1.0.17"
+    "react-scroll": "^1.0.17",
+    "react-tap-event-plugin": "~2.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",


### PR DESCRIPTION
The Style Guide now leverages "react-tap-event-plugin" [0]. Add this
dependency to the package.json. This plugin gives "tap" events without
the "delay" seen in iOS devices [1]. As noted in the project README [1],
Facebook is not planning on fixing this within React as it expects the
browsers to _soon_ correct the problem.

[0] https://github.com/zilverline/react-tap-event-plugin
[1] https://github.com/zilverline/react-tap-event-plugin#introduction

(cherry picked from commit 4f08f15e21ee2ca89f37c7cc8aae51a5df22a9a2)