### PR TITLE
Problem: module not found in import statement

### DIFF
--- a/guide/src/ThemeExList.js
+++ b/guide/src/ThemeExList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { P } from 'cyverse-ui';
 import { Code, Figure } from './components';
-import Paper from 'Material-ui/Paper';
+import Paper from 'material-ui/Paper';
 import ThemeEx from './examples/ThemeEx';
 import ThemeColorsEx from './examples/ThemeColorsEx';
 


### PR DESCRIPTION
## Description

While working on implementation Travis-CI for the `cyverse-ui` repository, I noticed there were errors importing components within the `/guide`:

https://travis-ci.org/lenards/cyverse-ui/builds/247661997#L206

This corrects one error contained in the `<ThemeExList />`. 

(cherry picked from commit 2308875005dd3db948e0b0796e346a8e93ac926e)