### PR TITLE
Problem: deploying Style Guide to GitHub Pages is manual

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: node_js
+node_js:
+- node
+install:
+- pushd ./guide
+- npm install
+- popd
+script:
+- pushd ./guide
+- npm run build
+- popd
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: ./guide/dist
+  name: CyVerse Deploy
+  email: cyverse-deploy@cyverse.org
+  on:
+    branch: master
+env:
+  global:
+    secure: NMVkxSHgbn5O9wj23zyjqSCfU05fUpdmWMknX60flIAyhd5HDwxcnSQ8xQUsaFP347ezb9pb3ldi2upxfcOveQpZRRk3eGfyyMU38shP3Ls1ZIRC2Id4MUnZKF0Sp0HvNcu3wIUmhmJIY1EqGGjHBNoWh9CRYsF1lg8RQ3oLBtuv+eUpSAyatYTr/71D8fhNfz0puk+MZeuq+msL4Xj/hokOLy0ea7LVK+JluTZtbsWtoVBfsCjpJIfRdlRN6zfVSG84wB+J5KyOGMCvi2hdk8pwqOGcef7GmaW7IDs0maIdRVNtUVdvl/Y4USWM0a2uu2hSE3DlUXXFd9E0idN9Gtwur9El8aQ1AJW+xC8oOhoAfIsBnfPM0I4PtsBBpuvfvxVQudwPS8CJB4ZNf5eB0qYhRlrDeUrjQ4Ld3HQEWIbFWukYwFSQ9tFy7CxeMjc3aKaDaORtKszAq1dq6zPkFnGSrkZDxZIRCZlynhsB/rTL2HYV7L7X2qi02FxkBrrGIPaEvT4u0UWWndUPJ2BaisL0c87yk3oVbbz7p/KKTHR3GIuQxXwwRXOQdOXDXosFHl34929zCDGygWdfDpb70ejmutW+zwd7+ICNNtGQ9YIvRoNCehT/3gWc2HJvV5cmkU8SJJ/J2lTS2tTAUwxZlyZjiPT+TQBHzN6O3pCdpyU=


### PR DESCRIPTION
## Define "auto-deploy" to GH Pages for Style Guide

This adds a Travis CI build definition that will install the dependencies for the "./guide" using `npm`, then do a full build/bundle of the Style Guide. On success, this will be deployed to GitHub Pages by Travis CI.

This work includes out-of-band actions to:
- create a CyVerse Deploy Agent GitHub account [0]
- sign that account up for Travis CI [1]
- invite that account to cyverse/cyverse-ui as a collaborator
- create a Personal Access Token (GITHUB_TOKEN) for that account,
  with correct permissions (see [2])
- add Travis CI to `cyverse-ui` repo as Integration/Service
  - this used the token from CyVerse Deploy Travis CI

Within this commit, we have defined a `deploy` step for Travis CI to take when a "build" is successful [3]. This uses a "deploy-provider" available from Travis CI.

Also, we have encrypted the GITHUB_TOKEN (aka GitHub PAT) to be securely included within the `.travis.yml` as an environment variables.

You can do a `gem install travis` to get the command-line interface [4].

Then, you can encrypt the variable, scoped to the repository, like so:

```bash
$ export GITHUB_TOKEN=aaaaredactedt0k3n
$ travis encrypt -r cyverse/cyverse-ui GITHUB_TOKEN=$GITHUB_TOKEN --add
```

Do this from the root of the repository, and it'll add the value as an encrypted value to the `.travis.yml` file.

@cyverse-deploy has *not* be added to the @cyverse org to avoid any leak of permissions. This add only has "write" permission to `cyverse/cyverse-ui`, by design.

Note: we are not using any development staff individual's GitHub Personal Access Token in this because it would be scoped to the account, not to the GitHub repository. When a newer version of GitHub PAT's are available that were "per repository" scoped, we could consider another
means.

THANK YOUs
----------

Thank you to @lthr for the write-up on deploying to GH Pages [5]. Even though we have opted for another approach, it was that blog that got the ball rolling, we appreciate that.

Thank you to @domenic for his gist [6], and bringing up the security concerns around using GitHub PATs.

[0] https://github.com/cyverse-deploy
[1] https://travis-ci.org/profile/cyverse-deploy
[2] https://docs.travis-ci.com/user/github-oauth-scopes/
[3] https://docs.travis-ci.com/user/deployment/pages/
[4] https://github.com/travis-ci/travis.rb#readme
[5] http://lthr.io/deploy-to-gh-pages
[6] https://gist.github.com/domenic/ec8b0fc8ab45f39403dd