### PR TITLE
Use example file for example code documentation

### DIFF
--- a/guide/package.json
+++ b/guide/package.json
@@ -18,6 +18,8 @@
   "homepage": "https://github.com/cyverse/cyverse-ui/blob/master/guide/README.md",
   "dependencies": {
     "cyverse-ui": "0.0.1",
+    "highlight.js": "^9.12.0",
+    "marked": "^0.3.6",
     "material-ui": "^0.17.1",
     "normalize.css": "^4.1.1",
     "radium": "^0.18.1",
@@ -43,6 +45,7 @@
     "file-loader": "^0.8.5",
     "gh-pages": "^0.11.0",
     "json-loader": "^0.5.4",
+    "raw-loader": "^0.5.1",
     "react-hot-loader": "^1.3.0",
     "style-loader": "^0.13.1",
     "webpack": "^1.12.9",

--- a/guide/src/ComponentExList.js
+++ b/guide/src/ComponentExList.js
@@ -13,6 +13,16 @@ import {
     VerticalMenuEx,
 } from './examples';
 
+import MediaCardExCode from '!raw!./examples/MediaCardEx';
+import TabsExCode from '!raw!./examples/TabsEx';
+import MeterGaugeExCode from '!raw!./examples/MeterGaugeEx';
+import ShowMoreEllipsisExCode from '!raw!./examples/ShowMoreEllipsisEx';
+import ProgressAvatarExCode from '!raw!./examples/ProgressAvatarEx';
+import PillExCode from '!raw!./examples/PillEx';
+import SubHeaderExCode from '!raw!./examples/SubHeaderEx';
+import ButtonMenuExCode from '!raw!./examples/ButtonMenuEx';
+import VerticalMenuExCode from '!raw!./examples/VerticalMenuEx';
+
 const ExampleList = [
     {
         name: "Pill",
@@ -24,6 +34,7 @@ const ExampleList = [
             </div>
         ), 
         render: PillEx,
+        code: PillExCode,
     },
     {
         name: "Tabs",
@@ -38,6 +49,7 @@ const ExampleList = [
             </div>
         ), 
         render: TabsEx,
+        code: TabsExCode,
     },
     {
         name: "MeterGauge",
@@ -47,6 +59,7 @@ const ExampleList = [
             </P>
         ),
         render: MeterGaugeEx,
+        code: MeterGaugeExCode,
     },
     {
         name: "ShowMoreEllipsis",
@@ -58,6 +71,7 @@ const ExampleList = [
             </div>
         ),
         render: ShowMoreEllipsisEx,
+        code: ShowMoreEllipsisExCode,
     },
     {
         name: "ProgressAvatar",
@@ -67,6 +81,7 @@ const ExampleList = [
             </P>
         ),
         render: ProgressAvatarEx,
+        code: ProgressAvatarExCode,
     },
     {
         name: "MediaCard",
@@ -76,6 +91,7 @@ const ExampleList = [
             </P>
         ),
         render: MediaCardEx,
+        code: MediaCardExCode,
     },
     {
         name: "SubHeader",
@@ -87,6 +103,7 @@ const ExampleList = [
             </div>
         ), 
         render: SubHeaderEx,
+        code: SubHeaderExCode,
     },
     {
         name: "ButtonMenu",
@@ -101,6 +118,7 @@ const ExampleList = [
             </div>
         ), 
         render: ButtonMenuEx,
+        code: ButtonMenuExCode,
     },
     {
         name: "VerticalMenu",
@@ -115,6 +133,7 @@ const ExampleList = [
             </div>
         ), 
         render: VerticalMenuEx,
+        code: VerticalMenuExCode,
     },
 ];
 

--- a/guide/src/StyleGuide.js
+++ b/guide/src/StyleGuide.js
@@ -6,24 +6,26 @@ import { styles } from './styles';
 import theme from './theme';
 import 'normalize.css';
 import './base.css';
+import './github.css';
 
 import ComponentExList from './ComponentExList';
 import ThemeExList from './ThemeExList';
 import { Header, SideNav, Figure, ThemeExamples } from './components';
+import MarkdownElement from './components/MarkdownElement';
+import Code from './components/Code';
 
 const scroller = Scroll.scroller;
 const ScrollAnchor = Scroll.Element;
 
 export default React.createClass({
     renderThemeExamples() {
-        return  ThemeExList.map( (component, i) => {
-            return (
+        return  ThemeExList.map( (component, i) => (
                 <ThemeExamples
                     component={ component }
                     i={ i }
                 />
             )
-        })
+        )
     },
 
     renderComponentExamples() {
@@ -31,6 +33,7 @@ export default React.createClass({
         let Name = Component.name;
         let Description = Component.desc;
         let Render = Component.render;
+        let code = Component.code;
         return (
                 <Section
                     key={ i }
@@ -60,6 +63,13 @@ export default React.createClass({
                         color={ theme.color.primary }
                     >
                         <Render/>
+                        <MarkdownElement
+                            style={{
+                                overflow: "scroll",
+                            }}
+                            text={ code }
+                        />
+
                     </Figure>
                 </Section>
             )

--- a/guide/src/ThemeExList.js
+++ b/guide/src/ThemeExList.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { P } from 'cyverse-ui';
-import { Code, Figure } from './components';
-import Paper from 'material-ui/Paper';
+import { Figure } from './components';
+import MarkdownElement from './components/MarkdownElement';
+import Paper from 'Material-ui/Paper';
 import ThemeEx from './examples/ThemeEx';
 import ThemeColorsEx from './examples/ThemeColorsEx';
 
@@ -11,7 +12,7 @@ const ThemeExList = [
         desc: (
             <div>
                 <P>
-                    The <code>cyverseTheme</code> is provided by the CyVerse-UI library and works with the Material-UI theme system to maintain a consistent "CyVerse look" across all applications using it.
+                    The <code className="CodeInline">cyverseTheme</code> is provided by the CyVerse-UI library and works with the Material-UI theme system to maintain a consistent "CyVerse look" across all applications using it.
                 </P>
 		<ThemeEx/>
             </div>
@@ -22,7 +23,7 @@ const ThemeExList = [
         desc: (
             <div>
                 <P>
-                    The <code>cyverseTheme</code> colors are part of a color system, encouraging proper contrast and consistency while enforcing the CyVerse band.
+                    The <code className="CodeInline">cyverseTheme</code> colors are part of a color system, encouraging proper contrast and consistency while enforcing the CyVerse band.
                 </P>
                 <P>
                     These colors can be overridden when initializing the Material-UI theme provider. See directions for this and installing the CyVerse theme below.
@@ -38,10 +39,10 @@ const ThemeExList = [
         desc: (
             <div>
                 <P>
-                    To use the CyVerse theme we need to wrap our entire application in the Material-UI theme provider (MuiThemeProvider) and initialize it with our custom CyVerse theme using "getMuiTheme" as our base theme. This will make the theme values available to all of the components.
+                    To use the CyVerse theme we need to wrap our entire application in the Material-UI theme provider <code className="CodeInline">MuiThemeProvider</code> and initialize it with our custom CyVerse theme using "getMuiTheme" as our base theme. This will make the theme values available to all of the components.
                 </P>
-                <Code>
-                    {
+                <MarkdownElement
+                    text={
 `import React from 'react';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
@@ -58,9 +59,8 @@ ReactDOM.render(
   <App />,
   document.getElementById('app')
 );`
-
                     }
-                </Code>
+                />
             </div>
         ),
     },
@@ -69,10 +69,10 @@ ReactDOM.render(
         desc: (
             <div>
                 <P>
-                    The <code>cyverseTheme</code> values can be used by your app specific components using Material-ui's "muiThemeable" module. To use export "muiThemeable" passing your component as a second argument.  The theme object will be available to your component through it's props.
+                    The <code className="CodeInline">cyverseTheme</code> values can be used by your app specific components using Material-ui's "muiThemeable" module. To use export "muiThemeable" passing your component as a second argument.  The theme object will be available to your component through it's props.
                 </P>
-                <Code>
-                    {
+                <MarkdownElement
+                    text={
 `import React from 'react';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 
@@ -103,7 +103,7 @@ const ThemeColorsEx = React.createClass({
 
 export default muiThemeable()(ThemeColorsEx);`
                     }
-                </Code>
+                />
             </div>
         ), 
     },

--- a/guide/src/base.css
+++ b/guide/src/base.css
@@ -22,3 +22,20 @@ a:hover {
     border-bottom: 2px solid lightgrey; 
 }
 
+code.lang-jsx, .CodeBlock {
+    display: block;
+    white-space: pre-wrap;
+    padding: 20px;
+    font-size: 14px;
+    border-left: solid rgba(0,0,0,.08) 5px;
+    background: rgba(0,0,0,0.03);
+}
+
+.CodeInline {
+    display: inline;
+    background: rgba(0,0,0,0.03);
+    border: solid rgba(0,0,0,.4) 1px;
+    border-radius: 3px;
+    color: firebrick;
+    padding: 0 3px 2px;
+}

--- a/guide/src/components/Figure.js
+++ b/guide/src/components/Figure.js
@@ -21,7 +21,7 @@ const Figure = React.createClass({
                         margin: "-11px -11px 20px",
                     }}
                 >
-                    <Title title noMarg>
+                    <Title title m={ 0 }>
                         { this.props.caption }
                     </Title>
                 </figcaption>

--- a/guide/src/components/MarkdownElement.js
+++ b/guide/src/components/MarkdownElement.js
@@ -1,0 +1,65 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import marked from 'marked';
+
+
+const styles = {
+  root: {
+    marginTop: 20,
+    marginBottom: 20,
+    padding: '0 10px',
+  },
+};
+
+class MarkdownElement extends Component {
+
+  static propTypes = {
+    style: PropTypes.object,
+    text: PropTypes.string.isRequired,
+  };
+
+  static defaultProps = {
+    text: '',
+  };
+
+  componentWillMount() {
+    marked.setOptions({
+      gfm: true,
+      tables: true,
+      breaks: false,
+      pedantic: false,
+      sanitize: false,
+      smartLists: true,
+      smartypants: false,
+      language: 'jsx',
+      highlight: function(code, lang) {
+        return require('highlight.js').highlight(lang, code).value;
+      },
+    });
+  }
+
+  render() {
+    const {
+      style,
+      text,
+    } = this.props;
+
+    const renderCode = (
+`\`\`\`jsx
+${text}
+\`\`\``
+    );
+
+    /* eslint-disable react/no-danger */
+    return (
+      <div
+        style={Object.assign({}, styles.root, style)}
+        className="markdown-body"
+        dangerouslySetInnerHTML={{__html: marked(renderCode)}}
+      />
+    );
+    /* eslint-enable */
+  }
+}
+
+export default MarkdownElement;

--- a/guide/src/components/index.js
+++ b/guide/src/components/index.js
@@ -6,6 +6,7 @@ export { default as Figure } from './Figure.js';
 export { default as Header } from './Header.js';
 export { default as SideBar } from './SideBar.js';
 export { default as SideNav } from './SideNav.js';
+export { default as MarkdownElement } from './MarkdownElement.js';
 export { default as ThemeExamples } from './ThemeExamples.js';
 export { default as ThemeLinkList } from './ThemeLinkList.js';
 

--- a/guide/src/examples/ButtonMenuEx.js
+++ b/guide/src/examples/ButtonMenuEx.js
@@ -27,122 +27,60 @@ export default React.createClass({
     render() {
 
         return (
-            <div>
-                <Paper style={{ padding: "10px", marginBottom: "20px" }}>
-                    <ButtonGroup>
-                        <ButtonMenu
-                            buttonLabel="Default"
-                            onItemTouchTap={ this.onSelectItem }
-                        >
-                            <MenuItem 
-                                primaryText="Instance"
-                            />
-                            <MenuItem 
-                                primaryText="Volume"
-                            />
-                            <MenuItem
-                                primaryText="Image"
-                            />
-                        </ButtonMenu>
-                        <ButtonMenu
-                            primary
-                            buttonLabel="Primary"
-                            onItemTouchTap={ this.onToggleMenu }
-                            onTouchTap={ this.onToggleMenu }
-                            anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
-                            targetOrigin={{horizontal: 'left', vertical: 'top'}}
-                        >
-                            <MenuItem 
-                                primaryText="Instance"
-                            />
-                            <MenuItem 
-                                primaryText="Volume"
-                            />
-                            <MenuItem
-                                primaryText="Image"
-                            />
-                        </ButtonMenu>
-                        <ButtonMenu
-                            secondary
-                            buttonLabel="Secondary"
-                            onItemTouchTap={ this.onToggleMenu }
-                            onTouchTap={ this.onToggleMenu }
-                            anchorOrigin={{horizontal: 'left', vertical: 'top'}}
-                            targetOrigin={{horizontal: 'left', vertical: 'bottom'}}
-                        >
-                            <MenuItem 
-                                primaryText="Instance"
-                            />
-                            <MenuItem
-                                primaryText="Volume" 
-                            />
-                            <MenuItem
-                                primaryText="Image"
-                            />
-                        </ButtonMenu>
-                    </ButtonGroup>
-                </Paper>
-                <Code children={
-                    /* This is a string for our code snippt. It is not indented because it messes up the formating in render 
-                     * started off using toJSX(Example) which was awesome but it renders the Radium wrapper instead of Button :( */
-`<Paper style={{ padding: "10px", marginBottom: "20px" }}>
-    <ButtonGroup>
-        <ButtonMenu
-            buttonLabel="Default"
-            onItemTouchTap={ this.onToggleMenu }
-            onTouchTap={ this.onToggleMenu }
-        >
-            <MenuItem
-                primaryText="Instance"
-            />
-            <MenuItem
-                primaryText="Volume"
-            />
-            <MenuItem
-                primaryText="Image"
-            />
-        </ButtonMenu>
-        <ButtonMenu
-            primary
-            buttonLabel="Primary"
-            onItemTouchTap={ this.onToggleMenu }
-            onTouchTap={ this.onToggleMenu }
-            anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
-            targetOrigin={{horizontal: 'left', vertical: 'top'}}
-        >
-            <MenuItem
-                primaryText="Instance"
-            />
-            <MenuItem
-                primaryText="Volume"
-            />
-            <MenuItem
-                primaryText="Image"
-            />
-        </ButtonMenu>
-        <ButtonMenu
-            secondary
-            buttonLabel="Secondary"
-            onItemTouchTap={ this.onToggleMenu }
-            onTouchTap={ this.onToggleMenu }
-            anchorOrigin={{horizontal: 'left', vertical: 'top'}}
-            targetOrigin={{horizontal: 'left', vertical: 'bottom'}}
-        >
-            <MenuItem
-                primaryText="Instance"
-            />
-            <MenuItem 
-                primaryText="Volume"
-            />
-            <MenuItem
-                primaryText="Image"
-            />
-        </ButtonMenu>
-    </ButtonGroup>
-</Paper>`
-                    /* Code string ends here */
-                }/>
-            </div>
+            <Paper style={{ padding: "10px", marginBottom: "20px" }}>
+                <ButtonGroup>
+                    <ButtonMenu
+                        buttonLabel="Default"
+                        onItemTouchTap={ this.onSelectItem }
+                    >
+                        <MenuItem
+                            primaryText="Instance"
+                        />
+                        <MenuItem
+                            primaryText="Volume"
+                        />
+                        <MenuItem
+                            primaryText="Image"
+                        />
+                    </ButtonMenu>
+                    <ButtonMenu
+                        primary
+                        buttonLabel="Primary"
+                        onItemTouchTap={ this.onToggleMenu }
+                        onTouchTap={ this.onToggleMenu }
+                        anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
+                        targetOrigin={{horizontal: 'left', vertical: 'top'}}
+                    >
+                        <MenuItem
+                            primaryText="Instance"
+                        />
+                        <MenuItem
+                            primaryText="Volume"
+                        />
+                        <MenuItem
+                            primaryText="Image"
+                        />
+                    </ButtonMenu>
+                    <ButtonMenu
+                        secondary
+                        buttonLabel="Secondary"
+                        onItemTouchTap={ this.onToggleMenu }
+                        onTouchTap={ this.onToggleMenu }
+                        anchorOrigin={{horizontal: 'left', vertical: 'top'}}
+                        targetOrigin={{horizontal: 'left', vertical: 'bottom'}}
+                    >
+                        <MenuItem
+                            primaryText="Instance"
+                        />
+                        <MenuItem
+                            primaryText="Volume"
+                        />
+                        <MenuItem
+                            primaryText="Image"
+                        />
+                    </ButtonMenu>
+                </ButtonGroup>
+            </Paper>
         )
     }
 });

--- a/guide/src/examples/InstanceCardEx.js
+++ b/guide/src/examples/InstanceCardEx.js
@@ -196,14 +196,6 @@ export default React.createClass({
                         />
 
                 </div>
-                <Code children={
-                    /* This is a string for our code snippt. It is not indented because it messes up the formating in render
-                     * started off using toJSX(Example) which was awesome but it renders the Radium wrapper instead of Button :( */
-`<div style={{marginBottom: "20px"}}>
-    <InstanceCard/>
-</div>`
-                    /* Code string ends here */
-                }/>
             </div>
         )
     }

--- a/guide/src/examples/MediaCardEx.js
+++ b/guide/src/examples/MediaCardEx.js
@@ -35,180 +35,87 @@ export default React.createClass({
         this.setState({ checked });
     },
 
-    Example() {
-        return (
-            <Div mb={ 4 }>
-                <MediaCardGroup>
-                    <MediaCard
-                        uid = "1"
-                        batchMode = { this.state.checked.length > 0 }
-                        checked = { this.state.checked.indexOf("1") !== -1 }
-                        onBatchClick = { this.onCheck }
-                        image={
-                            <Avatar 
-                                children="M"
-                                backgroundColor={ 
-                                    randomcolor({
-                                        seed: "MediaCard Example"
-                                    })}
-                                color="rgba(255,255,255,.7)"
-                            />
-                        }
-                        title={"MediaCard Example"}
-                        subTitle={"So much to say"}
-                        titleInfo= { 
-                            <div>
-                                <Pill>
-                                    Featured
-                                </Pill>
-                                <Pill
-                                    icon = { <PersonIcon/> } 
-                                >
-                                    23
-                                </Pill>
-                            </div>
-                        }
-                        summary="Bacon ipsum dolor amet turkey landjaeger ground round sausage"
-
-                        detail={ <div>
-                                    <P>
-                                        Bacon ipsum dolor amet turkey landjaeger ground round sausage flank strip steak. Cupim bresaola brisket beef pork belly turkey meatball ground round beef ribs tenderloin ham hock shankle swine chuck. Andouille short loin tail doner leberkas chicken cow venison shankle cupim hamburger beef ribs. Pastrami doner bacon, spare ribs prosciutto capicola andouille boudin.
-                                    </P>
-                                    <P>
-                                        Turkey biltong filet mignon meatloaf picanha. Turkey rump swine cupim porchetta beef shoulder shank beef ribs pork. Turducken corned beef ground round leberkas strip steak beef rump. Biltong swine corned beef, shankle andouille bacon tenderloin cow ball tip pancetta salami. Alcatra beef picanha short ribs chicken turducken ground round flank shankle pancetta. Meatball bacon biltong turducken.
-                                    </P>
-                                </div> 
-                        } 
-                        menuItems = {[
-                            <MenuItem key="1" primaryText="Refresh" />,
-                            <MenuItem key="2" primaryText="Send feedback" />,
-                            <MenuItem key="3" primaryText="Settings" />,
-                            <MenuItem key="4" primaryText="Help" />,
-                        ]}
-                    />
-                    <MediaCard 
-                        uid = "2"
-                        batchMode = { this.state.checked.length > 0 }
-                        checked = { this.state.checked.indexOf("2") !== -1 }
-                        onBatchClick = { this.onCheck }
-                        image={
-                            <Avatar
-                                children="W"
-                                backgroundColor={ 
-                                    randomcolor({
-                                        seed: "WithoutMenu"
-                                    })}
-                                color="rgba(255,255,255,.7)"
-                            />
-
-                        }
-                        title={"Without Menu"}
-                        summary="I don't have any subtitle data either"
-
-                        detail={ <div>
-                                    <P>
-                                        Bacon ipsum dolor amet turkey landjaeger ground round sausage flank strip steak. Cupim bresaola brisket beef pork belly turkey meatball ground round beef ribs tenderloin ham hock shankle swine chuck. Andouille short loin tail doner leberkas chicken cow venison shankle cupim hamburger beef ribs. Pastrami doner bacon, spare ribs prosciutto capicola andouille boudin.
-                                    </P>
-                                    <P>
-                                        Turkey biltong filet mignon meatloaf picanha. Turkey rump swine cupim porchetta beef shoulder shank beef ribs pork. Turducken corned beef ground round leberkas strip steak beef rump. Biltong swine corned beef, shankle andouille bacon tenderloin cow ball tip pancetta salami. Alcatra beef picanha short ribs chicken turducken ground round flank shankle pancetta. Meatball bacon biltong turducken.
-                                    </P>
-                                </div>
-                        } 
-                    />
-                </MediaCardGroup>
-            </Div>
-        )
-    },
-
     render() {
         return (
-            <div>
-                { this.Example() }
-                <Code children={
-                    /* This is a string for our code snippt.
-                     * It is not indented because it messes up the formating in render.
-                     * Initially used `toJSX(Example())` which was an awesome solution but it renders the Radium wrapper instead of Button :( */
-`<MediaCardGroup>
-    <MediaCard 
-        image={
-            <Avatar 
-                children="M"
-                backgroundColor={ 
-                    randomcolor({
-                        seed: "MediaCard Example"
-                    })}
-                color="rgba(255,255,255,.7)"
-            />
-        }
-        title={"MediaCard Example"}
-        subTitle={"So much to say"}
-        titleInfo= {
-            <div>
-                <Pill>
-                    Featured
-                </Pill>
-                <Pill
-                    icon = { <PersonIcon/> } 
-                >
-                    23
-                </Pill>
-            </div>
-        }
-        summary="Bacon ipsum dolor amet turkey landjaeger ground round sausage"
+            <MediaCardGroup>
+                <MediaCard
+                    uid = "1"
+                    batchMode = { this.state.checked.length > 0 }
+                    checked = { this.state.checked.indexOf("1") !== -1 }
+                    onBatchClick = { this.onCheck }
+                    image={
+                        <Avatar
+                            children="M"
+                            backgroundColor={
+                                randomcolor({
+                                    seed: "MediaCard Example"
+                                })}
+                            color="rgba(255,255,255,.7)"
+                        />
+                    }
 
-        detail={ <div>
-                    <P>
-                        Bacon ipsum dolor amet turkey landjaeger ground round sausage flank strip steak. Cupim bresaola brisket beef pork belly turkey meatball ground round beef ribs tenderloin ham hock shankle swine chuck. Andouille short loin tail doner leberkas chicken cow venison shankle cupim hamburger beef ribs. Pastrami doner bacon, spare ribs prosciutto capicola andouille boudin.
-                    </P>
-                    <P>
-                        Turkey biltong filet mignon meatloaf picanha. Turkey rump swine cupim porchetta beef shoulder shank beef ribs pork. Turducken corned beef ground round leberkas strip steak beef rump. Biltong swine corned beef, shankle andouille bacon tenderloin cow ball tip pancetta salami. Alcatra beef picanha short ribs chicken turducken ground round flank shankle pancetta. Meatball bacon biltong turducken.
-                    </P>
-                </div>
-        }
-        contextualMenu = {[
-            {render: "red"},
-            {render: "yellow"},
-            {render: "green"}
-        ]}
-        color={"#0971AB"}
-        onExpand={this.onExpand}
-        isExpanded={this.state.isExpanded}
-        menuItems = {[
-            <MenuItem key="1" primaryText="Refresh" />,
-            <MenuItem key="2" primaryText="Send feedback" />,
-            <MenuItem key="3" primaryText="Settings" />,
-            <MenuItem key="4" primaryText="Help" />,
-        ]}
-    />
-    <MediaCard 
-        image={
-            <Avatar
-                children="W"
-                backgroundColor={ 
-                    randomcolor({
-                        seed: "Without Menu"
-                    })}
-                color="rgba(255,255,255,.7)"
-            />
+                    subTitle={"So much to say"}
+                    titleInfo= {
+                        <div>
+                            <Pill>
+                                Featured
+                            </Pill>
+                            <Pill
+                                icon = { <PersonIcon/> }
+                            >
+                                23
+                            </Pill>
+                        </div>
+                    }
+                    summary="Bacon ipsum dolor amet turkey landjaeger ground round sausage"
 
-        }
-        title={"Without Menu"}
-        summary="I don't have any subtitle data either"
+                    detail={ <div>
+                                <P>
+                                    Bacon ipsum dolor amet turkey landjaeger ground round sausage flank strip steak. Cupim bresaola brisket beef pork belly turkey meatball ground round beef ribs tenderloin ham hock shankle swine chuck. Andouille short loin tail doner leberkas chicken cow venison shankle cupim hamburger beef ribs. Pastrami doner bacon, spare ribs prosciutto capicola andouille boudin.
+                                </P>
+                                <P>
+                                    Turkey biltong filet mignon meatloaf picanha. Turkey rump swine cupim porchetta beef shoulder shank beef ribs pork. Turducken corned beef ground round leberkas strip steak beef rump. Biltong swine corned beef, shankle andouille bacon tenderloin cow ball tip pancetta salami. Alcatra beef picanha short ribs chicken turducken ground round flank shankle pancetta. Meatball bacon biltong turducken.
+                                </P>
+                            </div>
+                    }
+                    menuItems = {[
+                        <MenuItem key="1" primaryText="Refresh" />,
+                        <MenuItem key="2" primaryText="Send feedback" />,
+                        <MenuItem key="3" primaryText="Settings" />,
+                        <MenuItem key="4" primaryText="Help" />,
+                    ]}
+                />
+                <MediaCard
+                    uid = "2"
+                    batchMode = { this.state.checked.length > 0 }
+                    checked = { this.state.checked.indexOf("2") !== -1 }
+                    onBatchClick = { this.onCheck }
+                    image={
+                        <Avatar
+                            children="W"
+                            backgroundColor={
+                                randomcolor({
+                                    seed: "WithoutMenu"
+                                })}
+                            color="rgba(255,255,255,.7)"
+                        />
 
-        detail={ <div>
-                    <P>
-                        Bacon ipsum dolor amet turkey landjaeger ground round sausage flank strip steak. Cupim bresaola brisket beef pork belly turkey meatball ground round beef ribs tenderloin ham hock shankle swine chuck. Andouille short loin tail doner leberkas chicken cow venison shankle cupim hamburger beef ribs. Pastrami doner bacon, spare ribs prosciutto capicola andouille boudin.
-                    </P>
-                    <P>
-                        Turkey biltong filet mignon meatloaf picanha. Turkey rump swine cupim porchetta beef shoulder shank beef ribs pork. Turducken corned beef ground round leberkas strip steak beef rump. Biltong swine corned beef, shankle andouille bacon tenderloin cow ball tip pancetta salami. Alcatra beef picanha short ribs chicken turducken ground round flank shankle pancetta. Meatball bacon biltong turducken.
-                    </P>
-                </div>
-        } 
-    />
-</MediaCardGroup>`
-                    /* Code string ends here */
-                }/>
-            </div>
+                    }
+                    title={"Without Menu"}
+                    summary="I don't have any subtitle data either"
+
+                    detail={ <div>
+                                <P>
+                                    Bacon ipsum dolor amet turkey landjaeger ground round sausage flank strip steak. Cupim bresaola brisket beef pork belly turkey meatball ground round beef ribs tenderloin ham hock shankle swine chuck. Andouille short loin tail doner leberkas chicken cow venison shankle cupim hamburger beef ribs. Pastrami doner bacon, spare ribs prosciutto capicola andouille boudin.
+                                </P>
+                                <P>
+                                    Turkey biltong filet mignon meatloaf picanha. Turkey rump swine cupim porchetta beef shoulder shank beef ribs pork. Turducken corned beef ground round leberkas strip steak beef rump. Biltong swine corned beef, shankle andouille bacon tenderloin cow ball tip pancetta salami. Alcatra beef picanha short ribs chicken turducken ground round flank shankle pancetta. Meatball bacon biltong turducken.
+                                </P>
+                            </div>
+                    }
+                />
+            </MediaCardGroup>
         )
     }
+
 });

--- a/guide/src/examples/MeterGaugeEx.js
+++ b/guide/src/examples/MeterGaugeEx.js
@@ -47,89 +47,45 @@ export default React.createClass({
         const { startValue, afterValue } = this.data();
         const dataTotal = Math.round(used + willUse);
         return (
-            <div>
-                <Paper 
+            <Paper
+                style={{
+                    ...marg({ mb:4 }),
+                    ...pad({ p:3 }),
+                }}
+            >
+                <div
                     style={{
-                        ...marg({ mb:4 }),
-                        ...pad({ p:3 }),
+                        maxWidth: "300px",
                     }}
                 >
-                    <div 
-                        style={{ 
-                            maxWidth: "300px",
-                        }}
-                    >
-                        <MeterGauge
-                            mb={ 3 }
-                            label="Thing Usage"
-                            data={ `Will total ${dataTotal}kg of ${totalAllowed}kg` }
-                            startValue={startValue}
-                            afterValue={afterValue}
-                            alertMessage="Hey, let's not get greedy"
-                        />
-                        <div style={ styles.t.label } >
-                            StartValue
-                        </div>
-                        <Slider 
-                            min={ 0 }
-                            max={ 100 }
-                            value={ startValue }
-                            onChange={ this.onStartChange }
-                        />
-                        <div style={ styles.t.label } >
-                            AfterValue
-                        </div>
-                        <Slider
-                            min={ 0 }
-                            max={ 100 }
-                            value={ afterValue }
-                            onChange={ this.onAfterChange }
-                        />
+                    <MeterGauge
+                        mb={ 3 }
+                        label="Thing Usage"
+                        data={ `Will total ${dataTotal}kg of ${totalAllowed}kg` }
+                        startValue={startValue}
+                        afterValue={afterValue}
+                        alertMessage="Hey, let's not get greedy"
+                    />
+                    <div style={ styles.t.label } >
+                        StartValue
                     </div>
-                </Paper>
-                <Code children={
-                    /* This is a string for our code snippt. It is not indented because it messes up the formating in render
-                     * started off using toJSX(Example) which was awesome but it renders the Radium wrapper instead of the Component name :( */
-`<Paper style={{
-        ...marg({ mb:4 }),
-        ...pad({ p:3 }),
-    }}
->
-    <div 
-        style={{ 
-            maxWidth: "300px",
-        }}
-    >
-        <MeterGauge
-            label="Thing Usage"
-            data={ \`Will total \${dataTotal}kg of \${totalAllowed}kg\` }
-            startValue={startValue}
-            afterValue={afterValue}
-            alertMessage="Hey, let's not get greedy"
-        />
-        <div style={ styles.t.label } >
-            StartValue
-        </div>
-        <Slider 
-            min={ 0 }
-            max={ 100 }
-            value={ startValue }
-            onChange={ this.onStartChange }
-        />
-        <div style={ styles.t.label } >
-            AfterValue
-        </div>
-        <Slider
-            min={ 0 }
-            max={ 100 }
-            value={ afterValue }
-            onChange={ this.onAfterChange }
-        />
-    </div>
-</Paper>`
-                    /* Code string ends here */
-                }/>
-            </div>
+                    <Slider
+                        min={ 0 }
+                        max={ 100 }
+                        value={ startValue }
+                        onChange={ this.onStartChange }
+                    />
+                    <div style={ styles.t.label } >
+                        AfterValue
+                    </div>
+                    <Slider
+                        min={ 0 }
+                        max={ 100 }
+                        value={ afterValue }
+                        onChange={ this.onAfterChange }
+                    />
+                </div>
+            </Paper>
         )
     }
 });

--- a/guide/src/examples/PillEx.js
+++ b/guide/src/examples/PillEx.js
@@ -16,92 +16,46 @@ const PillEx = React.createClass({
             } 
         } = this.props;
         return (
-            <section>
-                <Paper 
-                    style={{
-                        ...marg({ mb: 4 }),
-                        ...pad({ p: 3 }),
-                    }} 
-                >
-                    <Div mb = { 3 }>
-                        <Title
-                            h3
-                            title-1
-                            m={ 0 }
-                        >
-                            Default Color
-                        </Title>
-                        <Pill>
-                            Featured
-                        </Pill>
-                        <Pill icon = {  <PersonIcon/> } >
-                            22
-                        </Pill>
-                    </Div>
-                    <Div>
-                        <Title
-                            h3
-                            title-1
-                            m={ 0 }
-                        >
-                            Custom Color
-                        </Title>
-                        <Pill color={ primary1Color }>
-                            Featured
-                        </Pill>
-                        <Pill 
-                            color={ primary1Color }
-                            icon = {  <PersonIcon/> } 
-                        >
-                            22
-                        </Pill>
-                    </Div>
-                </Paper>
-            <Code
-                children={
-`<Paper 
-    style={{
-        ...marg({ mb: 4 }),
-        ...pad({ p: 3 }),
-    }} 
->
-    <Div mb = { 3 }>
-        <Title
-            h3
-            title-1
-            m={ 0 }
-        >
-            Default Color
-        </Title>
-        <Pill>
-            Featured
-        </Pill>
-        <Pill icon = {  <PersonIcon/> } >
-            22
-        </Pill>
-    </Div>
-    <Div>
-        <Title
-            h3
-            title-1
-            m={ 0 }
-        >
-            Custom Color
-        </Title>
-        <Pill color={ primary1Color }>
-            Featured
-        </Pill>
-        <Pill 
-            color={ primary1Color }
-            icon = {  <PersonIcon/> } 
-        >
-            22
-        </Pill>
-    </Div>
-</Paper>`
-                }
-            />
-            </section>
+            <Paper
+                style={{
+                    ...marg({ mb: 4 }),
+                    ...pad({ p: 3 }),
+                }}
+            >
+                <Div mb = { 3 }>
+                    <Title
+                        h3
+                        title-1
+                        m={ 0 }
+                    >
+                        Default Color
+                    </Title>
+                    <Pill>
+                        Featured
+                    </Pill>
+                    <Pill icon = {  <PersonIcon/> } >
+                        22
+                    </Pill>
+                </Div>
+                <Div>
+                    <Title
+                        h3
+                        title-1
+                        m={ 0 }
+                    >
+                        Custom Color
+                    </Title>
+                    <Pill color={ primary1Color }>
+                        Featured
+                    </Pill>
+                    <Pill
+                        color={ primary1Color }
+                        icon = {  <PersonIcon/> }
+                    >
+                        22
+                    </Pill>
+                </Div>
+            </Paper>
         )
     }
 });

--- a/guide/src/examples/ProgressAvatarEx.js
+++ b/guide/src/examples/ProgressAvatarEx.js
@@ -102,53 +102,6 @@ export default React.createClass({
                         icon={ <PlayIcon/> }
                     />
                 </div>
-                <Code
-                    children={
-
-`<Paper style={{ padding: "10px", marginBottom: "20px"}}>
-    <Div mb = { 3 } style={{ display: "flex", alignItems: "center" }}>
-        <ProgressAvatar
-            mr = { 3 }
-            percent = { this.state.progress }
-            src='https://www.fillmurray.com/500/500'
-        />
-        With an Image
-    </Div>
-    <Div mb = { 3 } style={{ display: "flex", alignItems: "center" }}>
-        <ProgressAvatar
-            mr = { 3 }
-            percent = { this.state.progress }
-            backgroundColor = "purple"
-        >
-            W
-        </ProgressAvatar>
-        With Text
-    </Div>
-    <Div mb = { 3 } style={{ display: "flex", alignItems: "center" }}>
-        <ProgressAvatar
-            mr = { 3 }
-            percent = { this.state.progress }
-            backgroundColor = "coral"
-            icon = { <PersonIcon color = "white"/> }
-        />
-        With Icon
-    </Div>
-    <Div style={{ display: "flex", alignItems: "center" }}>
-        <ProgressAvatar
-            mr = { 3 }
-            progressColor = "gold"
-            percent = { this.state.progress }
-            backgroundColor = "royalblue"
-            size = { 60 }
-            thickness = { 10 }
-        >
-            C
-        </ProgressAvatar>
-        Custom Progress Color, Size, and Progress Thickness!
-    </Div>
-</Paper>`
-                    }
-                />
             </div>
         )
     }

--- a/guide/src/examples/ShowMoreEllipsisEx.js
+++ b/guide/src/examples/ShowMoreEllipsisEx.js
@@ -7,29 +7,13 @@ import Paper from 'material-ui/Paper';
 export default React.createClass({
     render() {
         return (
-            <div>
-                <Paper style={{ padding: "10px", marginBottom: "20px"}} >
-                    <P>
-                        Bacon ipsum dolor amet capicola boudin tongue, cow pork loin venison t-bone kielbasa corned beef rump short loin tri-tip.
-                        <br/>
-                        <ShowMoreEllipsis/>
-                    </P>
-                </Paper>
-
-                <Code children={
-/* This is a string for our code snippt. It is not indented because it messes up the formating in render
- * started off using toJSX(Example) which was awesome but it renders the Radium wrapper instead of Button :( */
-`<Paper style={{ padding: "10px", marginBottom: "20px"}} >
-    <P>
-        Bacon ipsum dolor amet capicola boudin tongue, cow pork loin venison t-bone kielbasa corned beef rump short loin tri-tip.
-        <br/>
-        <ShowMoreEllipsis/>
-    </P>
-</Sheet>`
-                    /* Code string ends here */
-                }/>
-        </div>
-
+            <Paper style={{ padding: "10px", marginBottom: "20px"}} >
+                <P>
+                    Bacon ipsum dolor amet capicola boudin tongue, cow pork loin venison t-bone kielbasa corned beef rump short loin tri-tip.
+                    <br/>
+                    <ShowMoreEllipsis/>
+                </P>
+            </Paper>
         )
     },
 });

--- a/guide/src/examples/SubHeaderEx.js
+++ b/guide/src/examples/SubHeaderEx.js
@@ -49,46 +49,6 @@ export default React.createClass({
 
                     />
                 </Paper>
-            <Code
-                children={
-`<Paper style={{ padding: "5px", marginBottom: "20px"}} >
-    <SubHeader 
-        name="Title of View"
-        menuItems={[
-            <MenuItem key="1" primaryText="Refresh" />,
-            <MenuItem key="2" primaryText="Send feedback" />,
-            <MenuItem key="3" primaryText="Settings" />,
-            <MenuItem key="4" primaryText="Help" />,
-        ]}
-
-    />
-</Paper>
-<Paper style={{ padding: "5px", marginBottom: "20px"}} >
-    <SubHeader 
-        name="With QuickActions"
-        quickActions={[
-            <IconButton key="1">
-                <Share/>
-            </IconButton>,
-            <IconButton key="1">
-                <Edit size={ 20 }/>
-            </IconButton>,
-            <IconButton key="1">
-                <Delete size={ 20 }/>
-            </IconButton>,
-
-        ]}
-        menuItems={[
-            <MenuItem key="1" primaryText="Refresh" />,
-            <MenuItem key="2" primaryText="Send feedback" />,
-            <MenuItem key="3" primaryText="Settings" />,
-            <MenuItem key="4" primaryText="Help" />,
-        ]}
-
-    />
-</Paper>`
-                }
-            />
             </section>
         )
     }

--- a/guide/src/examples/TabsEx.js
+++ b/guide/src/examples/TabsEx.js
@@ -1,12 +1,10 @@
 import React, { PropType } from 'react';
 import { Tabs } from 'cyverse-ui';
 import Paper from 'material-ui/Paper';
-import { Code } from '../components';
 import theme from '../theme.js';
 
 export default React.createClass({
     getInitialState() {
-
         return {
             currentTab: 0,
         }
@@ -20,47 +18,22 @@ export default React.createClass({
 
     render() {
         return (
-            <div>
-                <Paper 
-                    style={{ 
-                        padding: "0 10px",
-                        marginBottom: "20px"
-                    }}
-                >
-                    <Tabs
-                        tabList={[
-                            "Red Fish",
-                            "Blue Fish",
-                            "Green Fish",
-                        ]}
-                        current={this.state.currentTab}
-                        color={ theme.color.primary }
-                        onTabClick={ this.onTabClick }
-                    />
-                </Paper>
-                <Code children={
-                    /* This is a string for our code snippt. It is not indented because it messes up the formating in render
-                     * started off using toJSX(Example) which was awesome but it renders the Radium wrapper instead of Button :( */
-`<Paper 
-    style={{ 
-        padding: "0 10px",
-        marginBottom: "20px"
-    }}
->
-    <Tabs
-        tabList={[
-            "Red Fish",
-            "Blue Fish",
-            "Green Fish",
-        ]}
-        current={this.state.currentTab}
-        color={ theme.color.primary }
-        onTabClick={ this.onTabClick }
-    />
-</Paper>`
-                    /* Code string ends here */
-                }/>
-            </div>
+            <Paper
+                style={{
+                    padding: "0 10px",
+                    marginBottom: "20px"
+                }}
+            >
+                <Tabs
+                    tabList={[
+                        "Red Fish",
+                        "Blue Fish",
+                        "Green Fish",
+                    ]}
+                    current={this.state.currentTab}
+                    onTabClick={ this.onTabClick }
+                />
+            </Paper>
         )
     }
 });

--- a/guide/src/examples/ThemeColorsEx.js
+++ b/guide/src/examples/ThemeColorsEx.js
@@ -5,7 +5,6 @@ import muiThemeable from 'material-ui/styles/muiThemeable';
 
 const ThemeColorsEx = React.createClass({
     getSwatch(color) {
-        console.log(this.props.muiTheme);
         return (
             <Paper
                 style={{

--- a/guide/src/examples/VerticalMenuEx.js
+++ b/guide/src/examples/VerticalMenuEx.js
@@ -31,29 +31,6 @@ export default React.createClass({
                         />
                     </VerticalMenu>
                 </Paper>
-                <Code children={
-                    /* This is a string for our code snippt. It is not indented because it messes up the formating in render 
-                     * started off using toJSX(Example) which was awesome but it renders the Radium wrapper instead of Button :( */
-`<Paper style={{ padding: "10px", marginBottom: "20px" }}>
-    <VerticalMenu
-        onItemTouchTap={ this.onSelect }
-    >
-        <MenuItem
-            key="1"
-            primaryText="Instance"
-        />
-        <MenuItem 
-            key="2"
-            primaryText="Volume"
-        />
-        <MenuItem
-            key="3"
-            primaryText="Image"
-        />
-    </VerticalMenu>
-</Paper>`
-                    /* Code string ends here */
-                }/>
             </div>
         )
     }

--- a/guide/src/github.css
+++ b/guide/src/github.css
@@ -1,0 +1,123 @@
+/*
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #333;
+  background: #f8f8f8;
+  -webkit-text-size-adjust: none;
+}
+
+.hljs-comment,
+.hljs-template_comment,
+.diff .hljs-header,
+.hljs-javadoc {
+  color: #998;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.css .rule .hljs-keyword,
+.hljs-winutils,
+.nginx .hljs-title,
+.hljs-subst,
+.hljs-request,
+.hljs-status {
+  color: #333;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-hexcolor,
+.ruby .hljs-constant {
+  color: #008080;
+}
+
+.hljs-string,
+.hljs-tag .hljs-value,
+.hljs-phpdoc,
+.hljs-dartdoc,
+.tex .hljs-formula {
+  color: #d14;
+}
+
+.hljs-title,
+.hljs-id,
+.scss .hljs-preprocessor {
+  color: #900;
+  font-weight: bold;
+}
+
+.hljs-list .hljs-keyword,
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-class .hljs-title,
+.hljs-type,
+.vhdl .hljs-literal,
+.tex .hljs-command {
+  color: #458;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-tag .hljs-title,
+.hljs-rules .hljs-property,
+.django .hljs-tag .hljs-keyword {
+  color: #000080;
+  font-weight: normal;
+}
+
+.hljs-attribute,
+.hljs-variable,
+.lisp .hljs-body {
+  color: #008080;
+}
+
+.hljs-regexp {
+  color: #009926;
+}
+
+.hljs-symbol,
+.ruby .hljs-symbol .hljs-string,
+.lisp .hljs-keyword,
+.clojure .hljs-keyword,
+.scheme .hljs-keyword,
+.tex .hljs-special,
+.hljs-prompt {
+  color: #990073;
+}
+
+.hljs-built_in {
+  color: #0086b3;
+}
+
+.hljs-preprocessor,
+.hljs-pragma,
+.hljs-pi,
+.hljs-doctype,
+.hljs-shebang,
+.hljs-cdata {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.diff .hljs-change {
+  background: #0086b3;
+}
+
+.hljs-chunk {
+  color: #aaa;
+}

--- a/guide/webpack.config.js
+++ b/guide/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const path = require('path');
 const validate = require('webpack-validator');
 const CleanPlugin = require('clean-webpack-plugin');
 
@@ -32,6 +33,15 @@ module.exports = validate({
                 include: RegExp(__dirname + "/src"),
                 loaders:["react-hot", "babel-loader"]
             },
+	    {
+		test: /\.txt$/,
+		loader: 'raw-loader',
+		include: path.resolve(__dirname, 'src/examples/raw-code'),
+	    },
+	    {
+		test: /\.md$/,
+		loader: 'raw-loader',
+	    },
             {
                 test: /\.css$/,
                 exclude: /\.useable\.css$/,


### PR DESCRIPTION
Before we were manually copy pasting our example source code into a string to render the accompanying code to our example. This caused the example code to often be out of date.

Now the code example is generated from the example source directly.

As a bonus syntax highlighting has been added.

CSS rules were added to to code class selectors that help with formatting our code elements since the code elements are generated by our markdown component. We will favor Components for code styling over CSS in the lib for consuming applications but for the guide in this case the CSS selectors are expectable. Once these components are added we might consider switching our instances here to use them for the sake of consistency.

<img width="1148" alt="screen shot 2017-07-05 at 11 50 58 am" src="https://user-images.githubusercontent.com/7366338/27879979-48c122ca-6178-11e7-8556-f38f57786b44.png">
