### PR TITLE
Regression: fix wrong capitalization on module import

### DIFF
--- a/guide/src/ThemeExList.js
+++ b/guide/src/ThemeExList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { P } from 'cyverse-ui';
 import { Figure } from './components';
 import MarkdownElement from './components/MarkdownElement';
-import Paper from 'Material-ui/Paper';
+import Paper from 'material-ui/Paper';
 import ThemeEx from './examples/ThemeEx';
 import ThemeColorsEx from './examples/ThemeColorsEx';
 


### PR DESCRIPTION
This fixes a regression caused by [this PR](https://github.com/cyverse/cyverse-ui/pull/41/files).

An import on `ThemeExamples.js` had the module capitalized do to a typo. This works locally but breaks in GH pages.   