### PR TITLE
Clean up guide's Code Examples

### DIFF
--- a/guide/src/ComponentExList.js
+++ b/guide/src/ComponentExList.js
@@ -13,15 +13,15 @@ import {
     VerticalMenuEx,
 } from './examples';
 
-import MediaCardExCode from '!raw!./examples/MediaCardEx';
-import TabsExCode from '!raw!./examples/TabsEx';
-import MeterGaugeExCode from '!raw!./examples/MeterGaugeEx';
-import ShowMoreEllipsisExCode from '!raw!./examples/ShowMoreEllipsisEx';
-import ProgressAvatarExCode from '!raw!./examples/ProgressAvatarEx';
-import PillExCode from '!raw!./examples/PillEx';
-import SubHeaderExCode from '!raw!./examples/SubHeaderEx';
-import ButtonMenuExCode from '!raw!./examples/ButtonMenuEx';
-import VerticalMenuExCode from '!raw!./examples/VerticalMenuEx';
+import MediaCardExCode from '!raw-loader!./examples/MediaCardEx';
+import TabsExCode from '!raw-loader!./examples/TabsEx';
+import MeterGaugeExCode from '!raw-loader!./examples/MeterGaugeEx';
+import ShowMoreEllipsisExCode from '!raw-loader!./examples/ShowMoreEllipsisEx';
+import ProgressAvatarExCode from '!raw-loader!./examples/ProgressAvatarEx';
+import PillExCode from '!raw-loader!./examples/PillEx';
+import SubHeaderExCode from '!raw-loader!./examples/SubHeaderEx';
+import ButtonMenuExCode from '!raw-loader!./examples/ButtonMenuEx';
+import VerticalMenuExCode from '!raw-loader!./examples/VerticalMenuEx';
 
 const ExampleList = [
     {

--- a/guide/src/base.css
+++ b/guide/src/base.css
@@ -34,8 +34,9 @@ code.lang-jsx, .CodeBlock {
 .CodeInline {
     display: inline;
     background: rgba(0,0,0,0.03);
-    border: solid rgba(0,0,0,.4) 1px;
+    border: solid rgba(0,0,0,.2) 1px;
     border-radius: 3px;
-    color: firebrick;
+    font-size: 11px;
+    color: crimson;
     padding: 0 3px 2px;
 }

--- a/guide/src/components/MarkdownElement.js
+++ b/guide/src/components/MarkdownElement.js
@@ -2,64 +2,63 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import marked from 'marked';
 
-
 const styles = {
-  root: {
-    marginTop: 20,
-    marginBottom: 20,
-    padding: '0 10px',
-  },
+    root: {
+        marginTop: 20,
+        marginBottom: 20,
+        padding: '0 10px',
+    },
 };
 
 class MarkdownElement extends Component {
 
-  static propTypes = {
-    style: PropTypes.object,
-    text: PropTypes.string.isRequired,
-  };
+    static propTypes = {
+        style: PropTypes.object,
+        text: PropTypes.string.isRequired,
+    };
 
-  static defaultProps = {
-    text: '',
-  };
+    static defaultProps = {
+        text: '',
+    };
 
-  componentWillMount() {
-    marked.setOptions({
-      gfm: true,
-      tables: true,
-      breaks: false,
-      pedantic: false,
-      sanitize: false,
-      smartLists: true,
-      smartypants: false,
-      language: 'jsx',
-      highlight: function(code, lang) {
-        return require('highlight.js').highlight(lang, code).value;
-      },
-    });
-  }
+    componentWillMount() {
+        marked.setOptions({
+            gfm: true,
+            tables: true,
+            breaks: false,
+            pedantic: false,
+            sanitize: false,
+            smartLists: true,
+            smartypants: false,
+            language: 'jsx',
+            highlight: (code, lang) => (
+                require('highlight.js').highlight(lang, code).value
+            ),
+        });
+    }
 
-  render() {
-    const {
-      style,
-      text,
-    } = this.props;
+    render() {
+        const {
+            style,
+            text,
+        } = this.props;
 
-    const renderCode = (
+        const renderCode = (
 `\`\`\`jsx
 ${text}
 \`\`\``
-    );
+        );
 
-    /* eslint-disable react/no-danger */
-    return (
-      <div
-        style={Object.assign({}, styles.root, style)}
-        className="markdown-body"
-        dangerouslySetInnerHTML={{__html: marked(renderCode)}}
-      />
-    );
-    /* eslint-enable */
-  }
+        /* eslint-disable react/no-danger */
+        return (
+            <div
+                style={{ ...styles.root, ...style}}
+                className="markdown-body"
+                dangerouslySetInnerHTML={{__html: marked(renderCode)}}
+            />
+        );
+        /* eslint-enable */
+    }
 }
 
 export default MarkdownElement;

--- a/guide/webpack.config.js
+++ b/guide/webpack.config.js
@@ -33,15 +33,6 @@ module.exports = validate({
                 include: RegExp(__dirname + "/src"),
                 loaders:["react-hot", "babel-loader"]
             },
-	    {
-		test: /\.txt$/,
-		loader: 'raw-loader',
-		include: path.resolve(__dirname, 'src/examples/raw-code'),
-	    },
-	    {
-		test: /\.md$/,
-		loader: 'raw-loader',
-	    },
             {
                 test: /\.css$/,
                 exclude: /\.useable\.css$/,


### PR DESCRIPTION
This addresses some points brought up in [this PR](https://github.com/cyverse/cyverse-ui/pull/41)

Change 2 space tabs to 4 space
Use conventional import flags ie: "raw-loader"
Remove unused raw-loader tests for `.txt` and `.md`
Adjust styles of inline code 