### PR TITLE
Remove react key warnings

### DIFF
--- a/guide/src/StyleGuide.js
+++ b/guide/src/StyleGuide.js
@@ -12,7 +12,6 @@ import ComponentExList from './ComponentExList';
 import ThemeExList from './ThemeExList';
 import { Header, SideNav, Figure, ThemeExamples } from './components';
 import MarkdownElement from './components/MarkdownElement';
-import Code from './components/Code';
 
 const scroller = Scroll.scroller;
 const ScrollAnchor = Scroll.Element;
@@ -21,6 +20,7 @@ export default React.createClass({
     renderThemeExamples() {
         return  ThemeExList.map( (component, i) => (
                 <ThemeExamples
+                    key={ i }
                     component={ component }
                     i={ i }
                 />

--- a/guide/src/examples/ThemeColorsEx.js
+++ b/guide/src/examples/ThemeColorsEx.js
@@ -7,6 +7,7 @@ const ThemeColorsEx = React.createClass({
     getSwatch(color) {
         return (
             <Paper
+                key={ color[0] }
                 style={{
                     margin: "1%",
                     color: "white",
@@ -18,9 +19,9 @@ const ThemeColorsEx = React.createClass({
                 }}
             >
                 <div style={{ padding: "5px", background: "rgba(0,0,0,.2"}}>
-                    {color[0]}
+                    { color[0] }
                     <br/>
-                    {color[1]}
+                    { color[1] }
                 </div>
             </Paper>
         )

--- a/src/SubHeader.js
+++ b/src/SubHeader.js
@@ -13,9 +13,9 @@ const SubHeader = React.createClass({
         let { quickActions, menuItems } = this.props;
         let style = this.style();
 
-        let renderQuickActions = (option) => {
+        let renderQuickActions = (option, i) => {
             return (
-                <Div>
+                <Div key={ option + i }>
                     { option }
                 </Div>
             )


### PR DESCRIPTION
React complains with a warning when unique keys are not added to components returned by map. This is because to rerender efficiently react wants to determine what has changed by comparing items with the same key rather than a deep object comparison. (At least that's a partial truth, can read more about it [here](https://facebook.github.io/react/docs/lists-and-keys.html#keys) )

This removes the react generated warnings by adding these keys to the returned components.  