### PR TITLE
Clean up

### DIFF
--- a/guide/package.json
+++ b/guide/package.json
@@ -23,6 +23,7 @@
     "material-ui": "^0.17.1",
     "normalize.css": "^4.1.1",
     "radium": "^0.18.1",
+    "ramda": "^0.23.0",
     "randomcolor": "^0.4.4",
     "react": "~15.4.0",
     "react-dom": "~15.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "material-ui"
   ],
   "scripts": {
-    "build": "babel -d . src; node makeTheme.js",
+    "build": "babel -d . src; node ./src/makeTheme.js",
     "watch": "babel -w -d . src"
   },
   "repository": {
@@ -43,6 +43,6 @@
     "babel-preset-stage-2": "^6.5.0",
     "eslint": "~2.2.0",
     "eslint-plugin-react": "^5.1.1",
-    "write-json": "^0.2.2"
+    "write-json": "^1.0.1"
   }
 }

--- a/src/MediaCardGroup.js
+++ b/src/MediaCardGroup.js
@@ -7,20 +7,20 @@ const MediaCardGroup = React.createClass({
             expanded: null
         }
     },
-    
-    componentDidMount: function() {
+
+    componentDidMount() {
         document.addEventListener('click', this.handleDocumentClick, false);
     },
 
-    componentWillUnmount: function() {
+    componentWillUnmount() {
         document.removeEventListener('click', this.handleDocumentClick, false);
     },
 
-    handleDocumentClick: function(e) {
+    handleDocumentClick(e) {
         let cards = this.refs.root;
         if (!cards.contains(e.target)) {
             this.setState({ expanded: null });
-        }
+            }
     },
 
     onExpand(el) {

--- a/src/ProgressAvatar.js
+++ b/src/ProgressAvatar.js
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 import { Div } from 'cyverse-ui';
 import Avatar from 'material-ui/Avatar';
 import CircleProgressBar from 'material-ui/CircularProgress';
-import muiThemeable from 'material-ui/styles/muiThemeable';
 
 const ProgressAvatar = React.createClass({
     render() {


### PR DESCRIPTION
I'm breaking up a bunch of work on the @next branch into more manageable PRs.

This is a general catch all of a few small changes:
* Include Ramda in package.json
  * Not sure why we are even building in travis because we import it [on this line](https://github.com/cyverse/cyverse-ui/blob/master/guide/src/examples/ThemeColorsEx.js#L2)
* Use shorthand object syntax to get named functions
  *  Not sure if this is the same as the es2015 feature or if this is babel / jsx behaviour because in this case we don't have to declare a variable first. This looks better IMO and we get named functions in stacktraces for free. ie: `{ name() }` equates to `{ name: function name()}`
* Fix build script to use correct theme path
  * The makeTheme.js script was moved without updating the build script. Because we published a build that had the theme already built we didn't hit this but changes to the theme exposed the issue.
* Move HOC import above components.
  * I like import order to be libs / utility functions, HOC, components from libs, components. There are probably different views on this.