### PR TITLE
Design improvement to MeterGauge

### DIFF
--- a/src/MeterGauge.js
+++ b/src/MeterGauge.js
@@ -21,7 +21,7 @@ export const MeterGauge =React.createClass({
 
     alert() {
         const {
-            alertMessage 
+            alertMessage
         } = this.props;
 
         return this.isOver() ? (
@@ -43,7 +43,7 @@ export const MeterGauge =React.createClass({
         return (
             <div style={ style.wrapper }>
                 <dl>
-                    <dt style={ style.label } >
+                    <dt style={ styles.t.label } >
                         {this.props.label}
                     </dt>
 
@@ -74,8 +74,11 @@ export const MeterGauge =React.createClass({
             danger = "red"
         } = muiTheme.palette;
 
-        const startColor = this.isOver() ? 
+        const startColor = this.isOver() ?
             danger : success;
+
+        const dataText = this.isOver() ?
+            danger : "#333333";
 
         // Start styles
         const wrapper = {
@@ -83,15 +86,10 @@ export const MeterGauge =React.createClass({
             height: "70px"
         }
 
-        const label = {
-            fontSize: "12px",
-            fontWeight: "600",
-            margin: "0 0 10px",
-        }
         const data = {
             ...styles.t.caption,
-            color: startColor, 
-            fontSize: "10px",
+            color: dataText,
+            fontSize: "13px",
             margin: "0px 0px 3px",
         }
         const bar = {
@@ -124,7 +122,6 @@ export const MeterGauge =React.createClass({
         // Combine Styles
         return {
             wrapper,
-            label,
             data,
             bar,
             barBefore,

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -25,8 +25,9 @@ let styleVariables = {
         label: {
             display: "block",
             fontSize: "12px",
-            fontWeight: "600",
-            margin: "0px 0px 8px",
+            fontWeight: "200",
+            color: "rgba(0, 0, 0, 0.3)",
+            margin: "0px 0px 10px",
         },
 
         caption: {


### PR DESCRIPTION
MUI uses a thin light gray font for labels. This is because it puts more weight on the content of the field value the label is for. Since MeterGuage often shows with a group of form elements it's label should match. 

The data text is also enlarged and black to better match the values in MUI form elements again to fit better in a form along with these elements. 

### Changes
* Larger data text size
* Data text black
* Label matches MUI form labels
* Change `styles.t.label` to MUI label styling for consistency on future components

### After
<img width="328" alt="screen shot 2017-07-13 at 10 38 31 am" src="https://user-images.githubusercontent.com/7366338/28179830-0d6976b4-67b8-11e7-9e40-e3ccb146b8a4.png">


### Before
<img width="331" alt="screen shot 2017-07-13 at 10 42 38 am" src="https://user-images.githubusercontent.com/7366338/28179826-069aefd4-67b8-11e7-9086-1cd9af352a06.png">
