### PR TITLE
Move Scroll behaviour to MediaCardGroup

### DIFF
--- a/src/MediaCard.js
+++ b/src/MediaCard.js
@@ -1,13 +1,10 @@
 import React from 'react';
 import Checkbox from 'material-ui/Checkbox';
 import Dimensions from 'react-dimensions';
-import Scroll from 'react-scroll';
 import VerticalMenu from './VerticalMenu';
 import Hr from './Hr';
 import styles from './styles/styles';
 import marg from './styles/marg';
-
-const scroll = Scroll.animateScroll;
 
 const MediaCard = React.createClass({
     getInitialState() {
@@ -33,11 +30,6 @@ const MediaCard = React.createClass({
 
     onExpand() {
         this.props.onExpand();
-        let scrollAmount = this.props.isExpanded ?
-          -30 : 30;
-        scroll.scrollMore(scrollAmount, {
-            duration: 95,
-        });
     },
 
     onCheck(e) {

--- a/src/MediaCardGroup.js
+++ b/src/MediaCardGroup.js
@@ -1,5 +1,8 @@
 import React, { PropTypes } from 'react';
+import Scroll from 'react-scroll';
 import { marg } from './styles';
+
+const scroll = Scroll.animateScroll;
 
 const MediaCardGroup = React.createClass({
     getInitialState() {
@@ -24,6 +27,13 @@ const MediaCardGroup = React.createClass({
     },
 
     onExpand(el) {
+        let scrollAmount = this.state.expanded ?
+          -30 : 30;
+        if ( !this.props.noScroll ) {
+            setTimeout(() => {scroll.scrollMore(scrollAmount, {
+                duration: 70,
+            })}, 2);
+        }
         let expanded = this.state.expanded === el ?
             null : el;
         this.setState({


### PR DESCRIPTION
There are circumstances where the scroll behaviour when expanding cards is not wanted. This moves the behaviour from MediaCard to MediaCardGroup and offers a `noScroll` prop to turn this behaviour off. 