### PR TITLE
Stagger animation

### DIFF
--- a/guide/src/ComponentExList.js
+++ b/guide/src/ComponentExList.js
@@ -21,6 +21,7 @@ import SearchBarExCode from '!raw-loader!./examples/SearchBarEx';
 import InfoBlockExCode from '!raw-loader!./examples/InfoBlockEx';
 import IdentityExCode from '!raw-loader!./examples/IdentityEx';
 import MediaCardExCode from '!raw-loader!./examples/MediaCardEx';
+import MediaCardGroupExCode from '!raw-loader!./examples/MediaCardGroupEx';
 import MeterGaugeExCode from '!raw-loader!./examples/MeterGaugeEx';
 import ShowMoreEllipsisExCode from '!raw-loader!./examples/ShowMoreEllipsisEx';
 import ProgressAvatarExCode from '!raw-loader!./examples/ProgressAvatarEx';
@@ -118,7 +119,16 @@ const ExampleList = [
         render: SkeletonListEx,
         code: SkeletonListExCode,
     },
-
+    {
+        name: "MediaCardGroup",
+        desc: (
+            <P>
+                MediaCardGroup is a wrapper for MediaCards that helps to manage opening and closing, scroll animation, and stagger animation of MediaCards as cildren.
+            </P>
+        ),
+        render: MediaCardGroupEx,
+        code: MediaCardGroupExCode,
+    },
     {
         name: "SubHeader",
         desc: (

--- a/guide/src/StyleGuide.js
+++ b/guide/src/StyleGuide.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Scroll from 'react-scroll';
 import {  Hr, P, Title, Div, Section } from 'cyverse-ui'; 
+import 'cyverse-ui/styles/animation.css'
 
 import { styles } from './styles';
 import theme from './theme';

--- a/guide/src/examples/MediaCardGroupEx.js
+++ b/guide/src/examples/MediaCardGroupEx.js
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import randomcolor from 'randomcolor';
+import { Avatar, FlatButton } from 'material-ui';
+import RefreshIcon from 'material-ui/svg-icons/navigation/refresh';
+import { MediaCardGroup, MediaCard, P, Title } from 'cyverse-ui';
+import { marg } from 'cyverse-ui/styles';
+
+export default class MediaCardGroupEx extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            refreshing: false
+        }
+    }
+
+    // Handler for refreshing the list
+    onRefresh = () => {
+        this.setState({
+            refreshing: true
+        });
+
+        setTimeout( () => {
+            this.setState({
+                refreshing: false
+            })
+        }, 1);
+    }
+
+    render() {
+        const { refreshing } = this.state;
+
+        // Genaric data for MediaCards
+        const summary="Include the 'stagger' prop to enable staggering"
+        const description = (
+            <P>
+                Include the 'stagger' prop to enable staggering. The scroll animation is default, to disable it include the 'noScroll' prop
+            </P>
+        )
+        
+        // Build our MedaCard list to render
+        const MediaCards = () => {
+            let arr =[]
+            for (var i = 0; i < 4; i++) {
+                arr.push(
+                    <MediaCard
+                        key={ i }
+                        image={
+                            <Avatar
+                                backgroundColor={
+                                    randomcolor({
+                                        seed: i + 20
+                                    })
+                                }
+                                children="I"
+                            />
+                        }
+                        title="I am a MediaCard"
+                        summary={ summary }
+                        detail={ description }
+                    />
+                )
+            }
+
+            return arr
+        };
+
+        return (
+            <div>
+                <FlatButton
+                    style={ marg({ mb: 4 }) }
+                    icon={<RefreshIcon/>}
+                    label="Replay Stagger"
+                    onTouchTap={ this.onRefresh }
+                />
+                <Title
+                    h2
+                    title
+                >
+                    With stagger and scroll animations
+                </Title>
+                <div style={{ height: "300px" }}>
+                    { refreshing ? null : (
+                        <MediaCardGroup
+                            stagger
+                            mb={ 5 }
+                        >
+                            { MediaCards() }
+                        </MediaCardGroup>
+                    ) }
+                </div>
+
+                <Title
+                    h2
+                    title
+                >
+                    No stagger or scroll animations
+                </Title>
+                <div style={{ height: "300px" }}>
+                    { refreshing ? null : (
+                        <MediaCardGroup
+                            noScroll
+                        >
+                            { MediaCards() }
+                        </MediaCardGroup>
+                    ) }
+                </div>
+            </div>
+        );
+    }
+}

--- a/guide/src/examples/index.js
+++ b/guide/src/examples/index.js
@@ -14,3 +14,4 @@ export { default as SearchBarEx } from './SearchBarEx.js';
 export { default as InfoBlockEx } from './InfoBlockEx.js';
 export { default as IdentityEx } from './IdentityEx.js';
 export { default as SkeletonListEx } from './SkeletonListEx.js';
+export { default as MediaCardGroupEx } from './MediaCardGroupEx.js';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "material-ui"
   ],
   "scripts": {
-    "build": "babel -d . src; node ./src/makeTheme.js",
+    "build": "babel -d . src; node ./src/makeTheme.js; cp ./src/styles/animation.css ./styles",
     "watch": "babel -w -d . src"
   },
   "repository": {
@@ -32,6 +32,7 @@
     "jss": "^7.1.5",
     "jss-preset-default": "^2.0.0",
     "jss-theme-reactor": "^0.11.1",
+    "react-css-stagger": "0.0.5",
     "react-ink": "6.2.0",
     "react-scroll": "1.5.2"
   },

--- a/src/MediaCard.js
+++ b/src/MediaCard.js
@@ -35,7 +35,10 @@ const MediaCard = React.createClass({
     },
 
     onExpand() {
-        this.props.onExpand();
+        const { onExpand } = this.props;
+        if (onExpand) {
+            onExpand();
+        }
     },
 
     onCheck(e) {
@@ -128,13 +131,14 @@ const MediaCard = React.createClass({
             title,
             subTitle,
             titleInfo,
-            summary
+            summary,
+            className
         } = this.props;
 
         const styles = this.styles();
 
         return (
-            <div style = {this.styles().card} >
+            <div className={ className } style = {this.styles().card} >
                 <div
                     style = { styles.header }
                     onMouseEnter = { this.onCardEnter }
@@ -237,6 +241,7 @@ const MediaCard = React.createClass({
         // title style
         style.title = {
             ...styles.t.body2,
+            width: "100%",
             marginRight: "20px",
             color: this.props.color,
         };

--- a/src/MediaCardGroup.js
+++ b/src/MediaCardGroup.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import Scroll from 'react-scroll';
+import Stagger from 'react-css-stagger';
 import { marg } from './styles';
 
 const scroll = Scroll.animateScroll;
@@ -28,11 +29,11 @@ const MediaCardGroup = React.createClass({
 
     onExpand(el) {
         let scrollAmount = this.state.expanded ?
-          -30 : 30;
+          -40 : 40;
         if ( !this.props.noScroll ) {
             setTimeout(() => {scroll.scrollMore(scrollAmount, {
-                duration: 70,
-            })}, 2);
+                duration: 60,
+            })}, 1);
         }
         let expanded = this.state.expanded === el ?
             null : el;
@@ -42,18 +43,32 @@ const MediaCardGroup = React.createClass({
     },
 
     render() {
-        let children = React.Children.map(this.props.children,
+        const { stagger } = this.props;
+
+        const children = React.Children.map(
+            this.props.children,
             (child) => React.cloneElement(child, {
                     onExpand: this.onExpand.bind(this, child),
                     isExpanded: this.state.expanded === child,
-                })
-            );
+                }
+            )
+        );
+
+        const renderList = stagger ? (
+                <Stagger
+                    transition="MediaCard__animation"
+                    delay={70}
+                >
+                    { children }
+                </Stagger>
+        ) : children;
+
         return (
-            <div 
-                style={ marg({ ...this.props}) }
+            <div
+                style={ marg(this.props) }
                 ref="root"
             >
-                { children } 
+                { renderList }
             </div>
         );
     }

--- a/src/styles/animation.css
+++ b/src/styles/animation.css
@@ -1,0 +1,10 @@
+.MediaCard__animation-enter {
+    opacity: 0;
+    transform: translate(0,10px);
+    transition:  opacity .2s ease, transform .2s ease !important;
+}
+
+.MediaCard__animation-enter-active {
+    opacity: 1;
+    transform: translate(0,0);
+}


### PR DESCRIPTION
This PR introduces an optional stagger effect when MediaCard lists are loaded. The reason is that when a filter is applied to a list there isn't enough indication that the list has changed, especially in the case where the top items are actually the same. By giving a little motion when loading a new list, it is more clear that the list has changed and prevents the otherwise disorienting flash.

### Cards staggering on mount
The gif frames seem to miss most of the animation. You can see a working example [here](http://project-resources.surge.sh/)
![stagger](https://user-images.githubusercontent.com/7366338/28381271-1698dd18-6c6f-11e7-95a6-4870acd881fe.gif)
