### PR TITLE
Fix issues with Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: node_js
 node_js:
 - node
 install:
+- npm install
 - pushd ./guide
 - npm install
 - popd
 script:
+- npm run build
 - pushd ./guide
 - npm run build
 - popd

--- a/guide/webpack.config.js
+++ b/guide/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = validate({
     resolve: {
         root: [__dirname + "/node_modules"],
         extensions: ["", ".js", ".jsx"],
+        alias: { "cyverse-ui": path.resolve( __dirname, "../") }
     },
     module: {
         loaders: [

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-preset-stage-2": "^6.5.0",
     "eslint": "~2.2.0",
     "eslint-plugin-react": "^5.1.1",
+    "material-ui": "~0.17.1",
     "write-json": "^1.0.1"
   }
 }


### PR DESCRIPTION
When Travis publishes our guide to GH page the cyverse-ui npm package is referenced
instead of the local lib source. This causes the GH page to fail because
the npm package doesn't contain the changes the guide depends on. Since the guide use npm link to reference the local lib source rather than the published npm package we don't see this problem locally. 

This commit adds a webpack alias to the local lib source.

Also, `makeTheme.js` uses `material-ui` to build our theme.json since we
include `material-ui` peer-dependency it isn't included in `node_modules` and fails.

Adds `material-ui` as a dev-dependency so that it still
doesn't bundle in the npm package but can use it for building.

Adds install and build scripts for lib to `.travis.yml`
