### PR TITLE
Problem: no configuration for eslint defined

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,27 +1,39 @@
 {
-    "rules": {
-        "linebreak-style": [
-            2,
-            "unix"
-        ],
-/*
-        "semi": [
-            2,
-            "always"
-        ],
- */
-        "no-debugger": 2,
-        "no-mixed-spaces-and-tabs": 2,
+
+    // We can use these as starting points for more strict linting
+    //
+    // "extends": [
+    //     "eslint:recommended",
+    //     "plugin:react/recommended",
+    // ],
+    "extends": [
+        "eslint:recommended",
+    ],
+
+    "ecmaFeatures": {
+        "jsx": true
     },
     "env": {
-        "es6": true,
-        "browser": true
+        "browser": true,
+        "commonjs": true,
+        "es6": true
     },
     "parser": "babel-eslint",
-    "ecmaFeatures": {
-        "jsx": true,
-    },
     "plugins": [
         "react"
-    ]
+    ],
+    "rules": {
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "no-unused-vars": [
+            "error",
+            {"args": "none"}
+        ],
+        "no-console": "warn",
+        "comma-dangle": "off",
+        "react/jsx-uses-react": "error",
+        "react/jsx-uses-vars": "error"
+    }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 - popd
 script:
 - npm run build
+- npm run lint
 - pushd ./guide
 - npm run build
 - popd

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-core": "^6.2.1",
-    "babel-eslint": "^6.*.*",
+    "babel-eslint": "^6.0.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-0": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "babel -d . src; node ./src/makeTheme.js; cp ./src/styles/animation.css ./styles",
+    "lint": "eslint -c .eslintrc --ext .jsx,.js --no-eslintrc src",
     "watch": "babel -w -d . src"
   },
   "repository": {
@@ -39,12 +40,12 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-core": "^6.2.1",
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^6.*.*",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-0": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
-    "eslint": "~2.2.0",
+    "eslint": "^2.13.*",
     "eslint-plugin-react": "^5.1.1",
     "material-ui": "~0.17.1",
     "write-json": "^1.0.1"


### PR DESCRIPTION
This provides a basic, eslint:recommended definition for the library. It borrows the `.eslintrc` from troposphere:master and upgrades the following packages:

- babel-eslint
- eslint

This does not address the react-plugin aspects of the lint configuration. This does not fix the violations created by applying the configuration to the repository/library.

This is the first of three pull requests. Please merge this first, when acceptable.