### PR TITLE
Add Identity component to guide

### DIFF
--- a/guide/src/ComponentExList.js
+++ b/guide/src/ComponentExList.js
@@ -31,6 +31,21 @@ import VerticalMenuExCode from '!raw-loader!./examples/VerticalMenuEx';
 
 const ExampleList = [
     {
+        name: "Identity",
+        desc: (
+            <div>
+                <P>
+                    Identity is used on a card or view to provide context to the content. A resource for example, would have the resource name as the primary text and useful meta as the secondary text, like the date the resource was created or a quick summary.
+                </P>
+                <P>
+                    An Identity is located at the top left of a card or view. A small Identity is used on cards and a large Identity or small Identity can be used on views.
+                </P>
+            </div>
+        ),
+        render: IdentityEx,
+        code: IdentityExCode,
+    },
+    {
         name: "InfoBlock",
         desc: (
             <div>


### PR DESCRIPTION
This adds the Identity Component to the guide.
<img width="945" alt="screen shot 2017-08-17 at 4 14 53 pm" src="https://user-images.githubusercontent.com/7366338/29437718-40df2f00-8367-11e7-80ca-03b8133f1565.png">

