### PR TITLE
Change components from using createClass to es6 classes

### DIFF
--- a/createComponent/compDocTemp.js
+++ b/createComponent/compDocTemp.js
@@ -8,8 +8,8 @@ import { parse } from 'react-docgen';
 import ${name} from '!raw-loader!cyverse-ui/${name}';
 const meta = parse(${name});
 
-const ${name}Doc = React.createClass({
-    render () {
+class ${name}Doc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ '${name} Example' } >
@@ -19,7 +19,7 @@ const ${name}Doc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default ${name}Doc;
 `);

--- a/guide/src/StyleGuide.js
+++ b/guide/src/StyleGuide.js
@@ -18,8 +18,8 @@ import IconSection from './iconDocs/IconSection';
 const scroller = Scroll.scroller;
 const ScrollAnchor = Scroll.Element;
 
-export default React.createClass({
-    renderThemeExamples() {
+export default class extends React.Component {
+    renderThemeExamples = () => {
         return  ThemeExList.map( (component, i) => (
                 <ThemeExamples
                     key={ i }
@@ -28,7 +28,7 @@ export default React.createClass({
                 />
             )
         )
-    },
+    };
 
     render() {
         const renderComponentList = R.toPairs(componentDocs)
@@ -86,9 +86,9 @@ export default React.createClass({
                 <footer/>
             </Div>
         )
-    },
+    }
 
-    style() {
+    style = () => {
         return {
             main: {
                 background: "whitesmoke",
@@ -102,5 +102,5 @@ export default React.createClass({
                 margin: "auto",
             }
         }
-    }
-})
+    };
+}

--- a/guide/src/componentDocs/ButtonMenu/ButtonMenuDoc.js
+++ b/guide/src/componentDocs/ButtonMenu/ButtonMenuDoc.js
@@ -9,8 +9,8 @@ import { parse } from 'react-docgen';
 import ButtonMenu from '!raw-loader!cyverse-ui/ButtonMenu';
 const meta = parse(ButtonMenu);
 
-const ButtonMenuDoc = React.createClass({
-    render () {
+class ButtonMenuDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `ButtonMenu Example` } >
@@ -20,6 +20,6 @@ const ButtonMenuDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default ButtonMenuDoc;

--- a/guide/src/componentDocs/ButtonMenu/ButtonMenuEx.js
+++ b/guide/src/componentDocs/ButtonMenu/ButtonMenuEx.js
@@ -1,19 +1,18 @@
-import React, { PropType } from 'react';
+import React from 'react';
 import MenuItem from 'material-ui/MenuItem';
 import { ButtonMenu } from 'cyverse-ui';
-import { ClearFix, ButtonGroup } from 'cyverse-ui/utils';
+import { ButtonGroup } from 'cyverse-ui/utils';
 import theme from '../../theme';
 import Paper from 'material-ui/Paper';
 
-export default React.createClass({
-
-    onSelectItem(e, item) {
+export default class extends React.Component {
+    onSelectItem = (e, item) => {
         console.log(
             `${item.props.primaryText} was selected!`
         );
-    },
+    };
 
-    menuItem({ id, name }) {
+    menuItem = ({ id, name }) => {
         return (
             <MenuItem
                 value={ id }
@@ -21,7 +20,7 @@ export default React.createClass({
                 color={ theme.color.primary }
             />
         )
-    },
+    };
 
     render() {
 
@@ -83,4 +82,4 @@ export default React.createClass({
             </Paper>
         )
     }
-});
+}

--- a/guide/src/componentDocs/FAB/FABDoc.js
+++ b/guide/src/componentDocs/FAB/FABDoc.js
@@ -9,8 +9,8 @@ import FAB from '!raw-loader!cyverse-ui/FAB';
 import { parse } from 'react-docgen';
 const meta = parse(FAB);
 
-const FABDoc = React.createClass({
-    render () {
+class FABDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `FAB Example` } >
@@ -20,6 +20,6 @@ const FABDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default FABDoc;

--- a/guide/src/componentDocs/Identity/IdentityDoc.js
+++ b/guide/src/componentDocs/Identity/IdentityDoc.js
@@ -9,8 +9,8 @@ import { parse } from 'react-docgen';
 import Identity from '!raw-loader!cyverse-ui/Identity';
 const meta = parse(Identity);
 
-const IdentityDoc = React.createClass({
-    render () {
+class IdentityDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `Identity Example` } >
@@ -20,6 +20,6 @@ const IdentityDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default IdentityDoc;

--- a/guide/src/componentDocs/InfoBlock/InfoBlockDoc.js
+++ b/guide/src/componentDocs/InfoBlock/InfoBlockDoc.js
@@ -11,8 +11,8 @@ import InfoBlockExCode from '!raw-loader!./InfoBlockEx';
 
 const meta = parse(InfoBlock);
 
-const InfoBlockDoc = React.createClass({
-    render () {
+class InfoBlockDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `InfoBlock Example` } >
@@ -22,6 +22,6 @@ const InfoBlockDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default InfoBlockDoc;

--- a/guide/src/componentDocs/InfoBlock/InfoBlockEx.js
+++ b/guide/src/componentDocs/InfoBlock/InfoBlockEx.js
@@ -4,7 +4,7 @@ import { pad, marg } from 'cyverse-ui/styles';
 import { Code }  from '../../components';
 import Paper from 'material-ui/Paper';
 
-const InfoBlockEx = React.createClass({
+class InfoBlockEx extends React.Component {
     render() {
         return (
             <Paper
@@ -24,6 +24,6 @@ const InfoBlockEx = React.createClass({
             </Paper>
         )
     }
-});
+}
 
 export default InfoBlockEx;

--- a/guide/src/componentDocs/MediaCard/MediaCardDoc.js
+++ b/guide/src/componentDocs/MediaCard/MediaCardDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import MediaCard from '!raw-loader!cyverse-ui/MediaCard';
 const meta = parse(MediaCard);
 
-const MediaCardDoc = React.createClass({
-    render () {
+class MediaCardDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `MediaCard Example` } >
@@ -23,6 +23,6 @@ const MediaCardDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default MediaCardDoc;

--- a/guide/src/componentDocs/MediaCard/MediaCardEx.js
+++ b/guide/src/componentDocs/MediaCard/MediaCardEx.js
@@ -9,15 +9,13 @@ import { Code } from '../../components';
 
 const v = variables;
 
-export default React.createClass({
-    getInitialState() {
-        return {
-            batchMode: true,
-            checked: [],
-        }
-    },
+export default class extends React.Component {
+    state = {
+        batchMode: true,
+        checked: [],
+    };
 
-    onCheck(e, item ) {
+    onCheck = (e, item) => {
         let list = this.state.checked;
         // We can set or use any prop we want for this check
         let curr = item.props.uid;
@@ -33,7 +31,7 @@ export default React.createClass({
         };
 
         this.setState({ checked });
-    },
+    };
 
     render() {
         return (
@@ -117,5 +115,4 @@ export default React.createClass({
             </MediaCardGroup>
         )
     }
-
-});
+}

--- a/guide/src/componentDocs/MediaCardGroup/MediaCardGroupDoc.js
+++ b/guide/src/componentDocs/MediaCardGroup/MediaCardGroupDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import MediaCardGroup from '!raw-loader!cyverse-ui/MediaCardGroup';
 const meta = parse(MediaCardGroup);
 
-const MediaCardGroupDoc = React.createClass({
-    render () {
+class MediaCardGroupDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `MediaCard Example` } >
@@ -23,6 +23,6 @@ const MediaCardGroupDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default MediaCardGroupDoc;

--- a/guide/src/componentDocs/MeterGauge/MeterGaugeDoc.js
+++ b/guide/src/componentDocs/MeterGauge/MeterGaugeDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import MeterGauge from '!raw-loader!cyverse-ui/MeterGauge';
 const meta = parse(MeterGauge);
 
-const MeterGaugeDoc = React.createClass({
-    render () {
+class MeterGaugeDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `MeterGauge Example` } >
@@ -23,6 +23,6 @@ const MeterGaugeDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default MeterGaugeDoc;

--- a/guide/src/componentDocs/MeterGauge/MeterGaugeEx.js
+++ b/guide/src/componentDocs/MeterGauge/MeterGaugeEx.js
@@ -5,16 +5,14 @@ import { pad, marg, styles } from 'cyverse-ui/styles';
 
 import Paper from 'material-ui/Paper';
 
-export default React.createClass({
-    getInitialState() {
-        return {
-            used: 40,
-            willUse: 130,
-            totalAllowed: 400,
-        }
-    },
+export default class extends React.Component {
+    state = {
+        used: 40,
+        willUse: 130,
+        totalAllowed: 400,
+    };
 
-    data() {
+    data = () => {
         const { used, willUse, totalAllowed } = this.state;
         const startValue = (used / totalAllowed) * 100;
         const afterValue = (willUse / totalAllowed) * 100;
@@ -22,23 +20,23 @@ export default React.createClass({
             startValue,
             afterValue,
         }
-    },
+    };
 
-    onStartChange(e, v) {
+    onStartChange = (e, v) => {
         const { totalAllowed } = this.state;
         const used = (v / 100) * totalAllowed;
         this.setState({
             used
         });
-    },
+    };
 
-    onAfterChange(e, v) {
+    onAfterChange = (e, v) => {
         const { totalAllowed } = this.state;
         const willUse = (v / 100) * totalAllowed;
         this.setState({
             willUse
         });
-    },
+    };
 
     render() {
         const { used, willUse, totalAllowed } = this.state;
@@ -86,4 +84,4 @@ export default React.createClass({
             </Paper>
         )
     }
-});
+}

--- a/guide/src/componentDocs/Pill/PillDoc.js
+++ b/guide/src/componentDocs/Pill/PillDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import Pill from '!raw-loader!cyverse-ui/Pill';
 const meta = parse(Pill);
 
-const PillDoc = React.createClass({
-    render () {
+class PillDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `Pill Example` } >
@@ -23,6 +23,6 @@ const PillDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default PillDoc;

--- a/guide/src/componentDocs/Pill/PillEx.js
+++ b/guide/src/componentDocs/Pill/PillEx.js
@@ -5,7 +5,7 @@ import PersonIcon from 'material-ui/svg-icons/social/person';
 import Paper from 'material-ui/Paper';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 
-const PillEx = React.createClass({
+class PillEx extends React.Component {
     render() {
         const {
             muiTheme: {
@@ -57,6 +57,6 @@ const PillEx = React.createClass({
             </Paper>
         )
     }
-});
+}
 
 export default muiThemeable()(PillEx);

--- a/guide/src/componentDocs/ProgressAvatar/ProgressAvatarDoc.js
+++ b/guide/src/componentDocs/ProgressAvatar/ProgressAvatarDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import ProgressAvatar from '!raw-loader!cyverse-ui/ProgressAvatar';
 const meta = parse(ProgressAvatar);
 
-const ProgressAvatarDoc = React.createClass({
-    render () {
+class ProgressAvatarDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `ProgressAvatar Example` } >
@@ -23,6 +23,6 @@ const ProgressAvatarDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default ProgressAvatarDoc;

--- a/guide/src/componentDocs/ProgressAvatar/ProgressAvatarEx.js
+++ b/guide/src/componentDocs/ProgressAvatar/ProgressAvatarEx.js
@@ -5,14 +5,12 @@ import { PlayIcon, PersonIcon } from '../../icons';
 import FlatButton from 'material-ui/FlatButton';
 import Paper from 'material-ui/Paper';
 
-export default React.createClass({
-    getInitialState() {
-        return {
-            progress: 100
-        }
-    },
+export default class extends React.Component {
+    state = {
+        progress: 100
+    };
 
-    startProccess() {
+    startProccess = () => {
 
         this.setState({
             progress: 20
@@ -38,13 +36,13 @@ export default React.createClass({
                 }, 1000);
             }, 2000);
         }, 1200);
-    },
+    };
 
-    replayProccess() {
+    replayProccess = () => {
         this.setState({
             progress: 0
         });
-    },
+    };
 
     render() {
         return (
@@ -101,4 +99,4 @@ export default React.createClass({
             </div>
         )
     }
-});
+}

--- a/guide/src/componentDocs/SearchBar/SearchBarDoc.js
+++ b/guide/src/componentDocs/SearchBar/SearchBarDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import SearchBar from '!raw-loader!cyverse-ui/SearchBar';
 const meta = parse(SearchBar);
 
-const SearchBarDoc = React.createClass({
-    render () {
+class SearchBarDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `SearchBar Example` } >
@@ -23,6 +23,6 @@ const SearchBarDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default SearchBarDoc;

--- a/guide/src/componentDocs/SearchBar/SearchBarEx.js
+++ b/guide/src/componentDocs/SearchBar/SearchBarEx.js
@@ -2,24 +2,22 @@ import React from 'react';
 import { SearchBar } from 'cyverse-ui';
 import Paper from 'material-ui/Paper';
 
-export default React.createClass({
-    getInitialState() {
-        return {
-            query: ""
-        }
-    },
+export default class extends React.Component {
+    state = {
+        query: ""
+    };
 
-    setQuery(e) {
+    setQuery = (e) => {
         this.setState({
             query: e.target.value
         })
-    },
+    };
 
-    clearQuery() {
+    clearQuery = () => {
         this.setState({
             query: ""
         })
-    },
+    };
 
     render() {
         return (
@@ -30,4 +28,4 @@ export default React.createClass({
             />
         )
     }
-});
+}

--- a/guide/src/componentDocs/ShowMoreEllipsis/ShowMoreEllipsisDoc.js
+++ b/guide/src/componentDocs/ShowMoreEllipsis/ShowMoreEllipsisDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import ShowMoreEllipsis from '!raw-loader!cyverse-ui/ShowMoreEllipsis';
 const meta = parse(ShowMoreEllipsis);
 
-const ShowMoreEllipsisDoc = React.createClass({
-    render () {
+class ShowMoreEllipsisDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `ShowMoreEllipsis Example` } >
@@ -23,6 +23,6 @@ const ShowMoreEllipsisDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default ShowMoreEllipsisDoc;

--- a/guide/src/componentDocs/ShowMoreEllipsis/ShowMoreEllipsisEx.js
+++ b/guide/src/componentDocs/ShowMoreEllipsis/ShowMoreEllipsisEx.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ShowMoreEllipsis, P } from 'cyverse-ui';
 import Paper from 'material-ui/Paper';
 
-export default React.createClass({
+export default class extends React.Component {
     render() {
         return (
             <Paper style={{ padding: "10px", marginBottom: "20px"}} >
@@ -13,5 +13,5 @@ export default React.createClass({
                 </P>
             </Paper>
         )
-    },
-});
+    }
+}

--- a/guide/src/componentDocs/SkeletonList/SkeletonListDoc.js
+++ b/guide/src/componentDocs/SkeletonList/SkeletonListDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import SkeletonList from '!raw-loader!cyverse-ui/SkeletonList';
 const meta = parse(SkeletonList);
 
-const SkeletonListDoc = React.createClass({
-    render () {
+class SkeletonListDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `SkeletonList Example` } >
@@ -23,6 +23,6 @@ const SkeletonListDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default SkeletonListDoc;

--- a/guide/src/componentDocs/SubHeader/SubHeaderDoc.js
+++ b/guide/src/componentDocs/SubHeader/SubHeaderDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import SubHeader from '!raw-loader!cyverse-ui/SubHeader';
 const meta = parse(SubHeader);
 
-const SubHeaderDoc = React.createClass({
-    render () {
+class SubHeaderDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `SubHeader Example` } >
@@ -23,6 +23,6 @@ const SubHeaderDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default SubHeaderDoc;

--- a/guide/src/componentDocs/SubHeader/SubHeaderEx.js
+++ b/guide/src/componentDocs/SubHeader/SubHeaderEx.js
@@ -6,7 +6,7 @@ import Delete from 'material-ui/svg-icons/action/delete';
 import Edit from 'material-ui/svg-icons/image/edit';
 import { SubHeader, Div, Title } from 'cyverse-ui';
 
-export default React.createClass({
+export default class extends React.Component {
     render() {
         return (
             <section>
@@ -37,4 +37,4 @@ export default React.createClass({
             </section>
         )
     }
-});
+}

--- a/guide/src/componentDocs/Tooltip/TooltipDoc.js
+++ b/guide/src/componentDocs/Tooltip/TooltipDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import Tooltip from '!raw-loader!cyverse-ui/Tooltip';
 const meta = parse(Tooltip);
 
-const TooltipDoc = React.createClass({
-    render () {
+class TooltipDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `Tooltip Example` } >
@@ -23,6 +23,6 @@ const TooltipDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default TooltipDoc;

--- a/guide/src/componentDocs/VerticalMenu/VerticalMenuDoc.js
+++ b/guide/src/componentDocs/VerticalMenu/VerticalMenuDoc.js
@@ -12,8 +12,8 @@ import { parse } from 'react-docgen';
 import VerticalMenu from '!raw-loader!cyverse-ui/VerticalMenu';
 const meta = parse(VerticalMenu);
 
-const VerticalMenuDoc = React.createClass({
-    render () {
+class VerticalMenuDoc extends React.Component {
+    render() {
         return (
             <ComponentDoc meta={ meta } >
                 <Figure caption={ `VerticalMenu Example` } >
@@ -23,6 +23,6 @@ const VerticalMenuDoc = React.createClass({
             </ComponentDoc>
         )
     }
-});
+}
 
 export default VerticalMenuDoc;

--- a/guide/src/componentDocs/VerticalMenu/VerticalMenuEx.js
+++ b/guide/src/componentDocs/VerticalMenu/VerticalMenuEx.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { VerticalMenu } from 'cyverse-ui';
 import { Paper, MenuItem } from 'material-ui';
 
-const VerticalMenuEx = React.createClass({
-    onSelect(e, ch) {
+class VerticalMenuEx extends React.Component {
+    onSelect = (e, ch) => {
         console.log(ch.props.primaryText);
-    },
+    };
 
     render() {
         return (
@@ -31,6 +31,6 @@ const VerticalMenuEx = React.createClass({
             </div>
         )
     }
-});
+}
 
 export default VerticalMenuEx;

--- a/guide/src/components/Code.js
+++ b/guide/src/components/Code.js
@@ -3,7 +3,7 @@ import { variables, marg } from 'cyverse-ui/styles';
 
 const v = variables
 
-export default React.createClass({
+export default class extends React.Component {
     render() {
         return (
             <code
@@ -11,9 +11,9 @@ export default React.createClass({
                 children={this.props.children}
             />
         )
-    },
+    }
 
-    style() {
+    style = () => {
         return {
             display: "block",
             whiteSpace: "pre-wrap",
@@ -24,6 +24,5 @@ export default React.createClass({
             background: "rgba(0,0,0,0.03)",
             ...marg(this.props),
         }
-    },
-
-});
+    };
+}

--- a/guide/src/components/ComponentDoc.js
+++ b/guide/src/components/ComponentDoc.js
@@ -17,12 +17,10 @@ import {
     MDBlock
 } from './';
 
-const scroller = Scroll.scroller;
 const ScrollAnchor = Scroll.Element;
 
-const ComponentDoc = React.createClass({
-
-    tableData(prop) {
+class ComponentDoc extends React.Component {
+    tableData = (prop) => {
         const defaultValue = prop[1].defaultValue;
         const renderDefault = defaultValue ? defaultValue.value: "";
         return (
@@ -45,11 +43,12 @@ const ComponentDoc = React.createClass({
                 </td>
             </tr>
         );
-    },
+    };
 
     render() {
         const { meta, children } = this.props;
         const { description, displayName } = meta;
+
         return (
             <Section
                 key={ displayName }
@@ -104,6 +103,6 @@ const ComponentDoc = React.createClass({
             </Section>
         )
     }
- });
+}
 
 export default ComponentDoc

--- a/guide/src/components/ComponentLinkList.js
+++ b/guide/src/components/ComponentLinkList.js
@@ -7,32 +7,29 @@ import {List, ListItem} from 'material-ui/List';
 import * as componentDocs from '../componentDocs';
 
 const scroller = Scroll.scroller;
-
-const ComponentLinkList = React.createClass({
-    scrollTo(name) {
+const scrollTo = target => {
         return () => {
-            let target = name.replace(/\s+/g, '-');
             scroller.scrollTo(target, {
                 duration: 1000,
                 smooth: true,
             });
         }
-    },
+    };
 
-    renderComponentLinks() {
+class ComponentLinkList extends React.Component {
+    renderComponentLinks = () => {
         return R.toPairs(componentDocs).map( item => {
             // This is kind of lame because the file ends with "doc"
             // Probably a better way to get the name off the component
             const name = item[0].slice(0, -3);
-            return ( 
+            return (
             <ListItem
-                key={ name }
-                onTouchTap={ this.scrollTo(name) }
+                onTouchTap={ scrollTo(name) }
                 primaryText= { name }
             />
             )
         })
-    },
+    };
 
     render() {
         return (
@@ -43,7 +40,7 @@ const ComponentLinkList = React.createClass({
                 Components
             </ListItem>
         )
-    },
-});
+    }
+}
 
 export default ComponentLinkList;

--- a/guide/src/components/Figure.js
+++ b/guide/src/components/Figure.js
@@ -3,8 +3,7 @@ import theme from '../theme';
 import { styles } from 'cyverse-ui/styles';
 import { Title } from 'cyverse-ui';
 
-const Figure = React.createClass({
-
+class Figure extends React.Component {
     render() {
         return (
             <figure style={{
@@ -30,7 +29,7 @@ const Figure = React.createClass({
 
         );
     }
-});
+}
 
 Figure.propTypes = {
     className: PropTypes.string,

--- a/guide/src/components/Header.js
+++ b/guide/src/components/Header.js
@@ -3,7 +3,7 @@ import { GithubIcon } from '../icons';
 import { pad } from 'cyverse-ui/styles';
 import CyverseLogo from '../icons/mini_logo.svg';
 
-export default React.createClass({
+export default class extends React.Component {
     render() {
         return (
                 <header
@@ -25,4 +25,4 @@ export default React.createClass({
                 </header>
         );
     }
-});
+}

--- a/guide/src/components/IconLink.js
+++ b/guide/src/components/IconLink.js
@@ -4,15 +4,15 @@ import {List, ListItem} from 'material-ui/List';
 
 const scroller = Scroll.scroller;
 
-const IconLink = React.createClass({
-    scrollTo(target) {
+class IconLink extends React.Component {
+    scrollTo = (target) => {
         return () => {
             scroller.scrollTo(target, {
                 duration: 1000,
                 smooth: true,
             });
         }
-    },
+    };
 
     render() {
         return (
@@ -21,7 +21,7 @@ const IconLink = React.createClass({
                 primaryText="SVG Icons"
             />
         )
-    },
-});
+    }
+}
 
 export default IconLink;

--- a/guide/src/components/SideBar.js
+++ b/guide/src/components/SideBar.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 
-const SideBar = React.createClass({
+class SideBar extends React.Component {
     render() {
         const openWidth = 250;
         const currentWidth = this.props.isOpen ? openWidth : 0; 
@@ -32,7 +32,7 @@ const SideBar = React.createClass({
             </nav>
         )
     }
-});
+}
 
 SideBar.propTypes = {
     className: PropTypes.string,

--- a/guide/src/components/SideNav.js
+++ b/guide/src/components/SideNav.js
@@ -6,7 +6,7 @@ import ComponentLinkList from './ComponentLinkList';
 import ThemeLinkList from './ThemeLinkList';
 import IconLink from './IconLink';
 
-const SideNav = React.createClass({
+class SideNav extends React.Component {
     render() {
         return (
             <SideBar isOpen >
@@ -23,7 +23,7 @@ const SideNav = React.createClass({
                 <IconLink/>
             </SideBar>
         )
-    },
-});
+    }
+}
 
 export default SideNav

--- a/guide/src/components/ThemeExamples.js
+++ b/guide/src/components/ThemeExamples.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import Scroll from 'react-scroll';
 import muiThemeable from 'material-ui/styles/muiThemeable';
-import {  Hr, P, Title, Div, Section } from 'cyverse-ui'; 
+import {  Hr, P, Title, Div, Section } from 'cyverse-ui';
 import Figure from './Figure';
 
 const scroller = Scroll.scroller;
 const ScrollAnchor = Scroll.Element;
 
-const ThemeExample = React.createClass({    
+class ThemeExample extends React.Component {
     render() {
         const { component, i, muiTheme } = this.props;
         const { name, desc } = component;
@@ -37,7 +37,7 @@ const ThemeExample = React.createClass({
                 { desc } 
             </Section>
         )
-    },
-});
+    }
+}
 
 export default muiThemeable()(ThemeExample);

--- a/guide/src/components/ThemeLinkList.js
+++ b/guide/src/components/ThemeLinkList.js
@@ -7,8 +7,8 @@ import ThemeExList from '../themeDocs/ThemeExList';
 
 const scroller = Scroll.scroller;
 
-const ThemeLinkList = React.createClass({
-    scrollTo(name) {
+class ThemeLinkList extends React.Component {
+    scrollTo = (name) => {
         return () => {
             let target = name.replace(/\s+/g, '-');
             scroller.scrollTo(target, {
@@ -16,9 +16,9 @@ const ThemeLinkList = React.createClass({
                 smooth: true,
             });
         }
-    },
+    };
 
-    renderComponentLinks() {
+    renderComponentLinks = () => {
         return ThemeExList.map( item => {
             return ( 
             <ListItem
@@ -28,7 +28,7 @@ const ThemeLinkList = React.createClass({
             />
             )
         })
-    },
+    };
 
     render() {
         return (
@@ -39,7 +39,7 @@ const ThemeLinkList = React.createClass({
                 Using The Theme
             </ListItem>
         )
-    },
-});
+    }
+}
 
 export default ThemeLinkList;

--- a/guide/src/iconDocs/IconEx.js
+++ b/guide/src/iconDocs/IconEx.js
@@ -4,7 +4,7 @@ import { pad, marg } from 'cyverse-ui/styles';
 import { Div } from 'cyverse-ui';
 import { LaunchIcon, LinkIcon } from 'cyverse-ui/icons';
 
-const IconEx = React.createClass({
+class IconEx extends React.Component {
     render() {
         return (
             <Paper style={pad({p:3})}>
@@ -27,6 +27,6 @@ const IconEx = React.createClass({
             </Paper>
         );
     }
-});
+}
 
 export default IconEx

--- a/guide/src/iconDocs/IconSection.js
+++ b/guide/src/iconDocs/IconSection.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Scroll from 'react-scroll';
 import R from 'ramda';
-import {  Hr, P, Title, Div, Section } from 'cyverse-ui'; 
+import {  Hr, P, Title, Div, Section } from 'cyverse-ui';
 import * as icons from 'cyverse-ui/icons';
 
 import theme from '../theme';
@@ -13,8 +13,8 @@ import IconExCode from '!raw-loader!./IconEx';
 const scroller = Scroll.scroller;
 const ScrollAnchor = Scroll.Element;
 
-const IconSection = React.createClass({
-    IconCell(icon) {
+class IconSection extends React.Component {
+    IconCell = (icon) => {
         const Icon = icon[1];
         const style = {
             cell: {
@@ -38,7 +38,7 @@ const IconSection = React.createClass({
                 </P>
             </Div>
         );
-    },
+    };
 
     render() {
         return (
@@ -86,6 +86,6 @@ const IconSection = React.createClass({
             </Section>
         );
     }
-})
+}
 
 export default IconSection

--- a/guide/src/icons/PlayIcon.js
+++ b/guide/src/icons/PlayIcon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import IconBase from './IconBase';
 
-export default React.createClass({
+export default class extends React.Component {
     render() {
         return (
             <IconBase viewBox="0 0 24 24" {...this.props}>
@@ -10,4 +10,4 @@ export default React.createClass({
             </IconBase>
         )
     }
-});
+}

--- a/guide/src/icons/ReplayIcon.js
+++ b/guide/src/icons/ReplayIcon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import IconBase from './IconBase';
 
-export default React.createClass({
+export default class extends React.Component {
     render() {
         return (
             <IconBase viewBox="0 0 24 24" {...this.props}>
@@ -10,4 +10,4 @@ export default React.createClass({
             </IconBase>
         )
     }
-});
+}

--- a/guide/src/themeDocs/ThemeColorsEx.js
+++ b/guide/src/themeDocs/ThemeColorsEx.js
@@ -3,8 +3,8 @@ import R from 'ramda';
 import Paper from 'material-ui/Paper';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 
-const ThemeColorsEx = React.createClass({
-    getSwatch(color) {
+class ThemeColorsEx extends React.Component {
+    getSwatch = (color) => {
         return (
             <Paper
                 key={ color[0] }
@@ -25,7 +25,7 @@ const ThemeColorsEx = React.createClass({
                 </div>
             </Paper>
         )
-    },
+    };
 
     render() {
         const {
@@ -48,6 +48,6 @@ const ThemeColorsEx = React.createClass({
             </div>
         )
     }
-});
+}
 
 export default muiThemeable()(ThemeColorsEx);

--- a/guide/src/utils/ButtonGroup.js
+++ b/guide/src/utils/ButtonGroup.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { marg } from 'cyverse-ui/styles';
 import ClearFix from './ClearFix';
 
-export default React.createClass({
+export default class extends React.Component {
     render() {
         let children = React.Children.map(this.props.children,
             (child) => React.cloneElement(child, {
@@ -15,4 +15,4 @@ export default React.createClass({
             </ClearFix>
         )
     }
-});
+}

--- a/src/ButtonMenu.js
+++ b/src/ButtonMenu.js
@@ -9,10 +9,10 @@ import Menu from 'material-ui/Menu';
 
 As a general rule menus should appear to the top right of the view so this component defaults to opening from the right and down but can be overridden using `anchorOrigin` and `targetOrigin`. See [Material-UI's Popover](http://www.material-ui.com/#/components/popover) for better documentation.
  */
-export default React.createClass({
+export default class extends React.Component {
+    static displayName = "ButtonMenu";
 
-    displayName: "ButtonMenu",
-    propTypes: {
+    static propTypes = {
         /**
          * Override the inline-styles of the root element.
          */
@@ -45,35 +45,33 @@ export default React.createClass({
          * This is the point on the popover which will attach to the anchor's origin. Options: vertical: [top, center, bottom] horizontal: [left, middle, right].
          */
         targetOrigin: React.PropTypes.object,
-    },
+    };
 
-    getInitialState() {
-        return {
-            open: false,
-        };
-    },
+    state = {
+        open: false,
+    };
 
-    handleTouchTap(event) {
+    handleTouchTap = (event) => {
         // This prevents ghost click.
         event.preventDefault();
         this.setState({
             open: true,
             anchorEl: event.currentTarget,
         });
-    },
+    };
 
-    handleRequestClose() {
+    handleRequestClose = () => {
         this.setState({
             open: false,
         });
-    },
+    };
 
-    handleItemTouchTap(e, item) {
+    handleItemTouchTap = (e, item) => {
         this.props.onItemTouchTap(e, item);
         this.setState({
             open: false,
         });
-    },
+    };
 
     render() {
         const {
@@ -119,5 +117,5 @@ export default React.createClass({
                 </Popover>
             </Div>
         )
-    },
-});
+    }
+}

--- a/src/Div.js
+++ b/src/Div.js
@@ -1,11 +1,10 @@
 import React, { PropTypes } from 'react';
 import { marg, pad } from './styles';
 
-const Div = React.createClass({
-
-/**
- * Div is a primitive layout component
- */
+class Div extends React.Component {
+    /**
+     * Div is a primitive layout component
+     */
     render() {
         return (
             <div 
@@ -15,9 +14,9 @@ const Div = React.createClass({
                 { this.props.children }
             </div>
         );
-    },
+    }
 
-    styles() {
+    styles = () => {
         let display="block";
 
         if (this.props.flex) {
@@ -32,8 +31,8 @@ const Div = React.createClass({
             ...pad(this.props),
             ...this.props.style,
         }
-    },
-});
+    };
+}
 
 Div.propTypes = {
     className: PropTypes.string,

--- a/src/FAB.js
+++ b/src/FAB.js
@@ -17,7 +17,7 @@ const FAB = createClass({
         }
     },
 
-    displayName: "FABMenu",
+    displayName: "FAB",
 
     propTypes: {
         /**

--- a/src/Hr.js
+++ b/src/Hr.js
@@ -1,23 +1,24 @@
 import React from 'react';
 import { marg } from './styles';
 
-export default React.createClass({
-/**
- * Hr renders the proper styling on a horizontal rule.
- */
-    style() {
+export default class extends React.Component {
+    /**
+     * Hr renders the proper styling on a horizontal rule.
+     */
+    static displayName = "Hr"
+    style = () => {
         return {
-            border:"0px", 
-            height: "1px", 
+            border:"0px",
+            height: "1px",
             background: "rgba( 0, 0, 0, .1 )",
             ...marg(this.props),
             ...this.props.style,
         }
-    },
+    };
 
     render() {
         return (
             <hr style={ this.style() }/>
         )
     }
-});
+}

--- a/src/InfoBlock.js
+++ b/src/InfoBlock.js
@@ -7,11 +7,10 @@ import { marg } from "./styles";
 /**
  * The InfoBlock is used everywhere information is displayed to the user that isn't part of an input or title. Usually at the top of a view to explain the purpose of said view. The icon helps isolate the information from the UI.
  */
-export default React.createClass({
+export default class extends React.Component {
+    static displayName = "InfoBlock";
 
-    displayName: "InfoBlock",
-
-    propTypes: {
+    static propTypes = {
         /**
          * The information text that will be displayed.
          */
@@ -20,15 +19,13 @@ export default React.createClass({
          * Show the warning icon over the default info icon
          */
         warning: React.PropTypes.bool,
-    },
+    };
 
-    getDefaultProps() {
-        return {
-            warning: false,
-        };
-    },
+    static defaultProps = {
+        warning: false,
+    };
 
-    icon() {
+    icon = () => {
         const { warning } = this.props;
         if (warning) {
             return (
@@ -42,7 +39,7 @@ export default React.createClass({
                 style={marg({ mr: 3})}
             />
         )
-    },
+    };
 
     render() {
         return (
@@ -59,4 +56,4 @@ export default React.createClass({
             </div>
         )
     }
-});
+}

--- a/src/MediaCard.js
+++ b/src/MediaCard.js
@@ -9,9 +9,10 @@ import marg from './styles/marg';
 /**
 * MediaCards are used for objects like Projects, Project Resources, and Images that have their own information and actions associated with them. They typically have a short description and a long description that can be seen by expanding the card. A contextual menu, attached to the card, contains all of the actions for that card.
  */
-const MediaCard = React.createClass({
-    displayName: "MediaCard",
-    propTypes: {
+class MediaCard extends React.Component {
+    static displayName = "MediaCard";
+
+    static propTypes = {
         /**
          * Expects MUI Avatar
          */
@@ -72,50 +73,48 @@ const MediaCard = React.createClass({
          * Classes applied to root element of card
          */
         className: PropTypes.string,
-    },
+    };
 
-    getInitialState() {
-        return {
-            cardIsHovered: false,
-            avatarIsHovered: false,
-        }
-    },
+    state = {
+        cardIsHovered: false,
+        avatarIsHovered: false,
+    };
 
-    stopPropagation(e) {
+    stopPropagation = (e) => {
         e.nativeEvent.stopImmediatePropagation();
         e.preventDefault();
         e.stopPropagation();
-    },
+    };
 
-    onCardEnter() {
+    onCardEnter = () => {
         this.setState({
             avatarIsHovered: true,
             cardIsHovered: true,
         });
-    },
+    };
 
-    onCardLeave() {
+    onCardLeave = () => {
         this.setState({
             avatarIsHovered: false,
             cardIsHovered: false,
         });
-    },
+    };
 
-    onExpand() {
+    onExpand = () => {
         const { onExpand } = this.props;
         if (onExpand) {
             onExpand();
         }
-    },
+    };
 
-    onCheck(e) {
+    onCheck = (e) => {
         e.nativeEvent.stopImmediatePropagation();
         e.preventDefault();
         e.stopPropagation();
         this.props.onBatchClick(e, this);
-    },
+    };
 
-    renderQuickLinks() {
+    renderQuickLinks = () => {
         const { quickLinks } = this.props;
         if ( quickLinks ) {
             return (
@@ -126,9 +125,9 @@ const MediaCard = React.createClass({
                 </div>
             )
         }
-    },
+    };
 
-    renderActiveQuickLinks() {
+    renderActiveQuickLinks = () => {
         const { activeQuickLinks } = this.props;
         if ( activeQuickLinks ) {
             return (
@@ -140,9 +139,9 @@ const MediaCard = React.createClass({
             )
         }
 
-    },
+    };
 
-    renderVericalMenu() {
+    renderVericalMenu = () => {
         const { menuItems, isDisabledMenu } = this.props;
         if ( menuItems ) {
             return (
@@ -152,9 +151,9 @@ const MediaCard = React.createClass({
                 />
             )
         }
-    },
+    };
 
-    renderAvatar() {
+    renderAvatar = () => {
         const { image, batchMode, onBatchClick } = this.props;
         const { avatarIsHovered } = this.state;
         const styles = this.styles();
@@ -178,9 +177,9 @@ const MediaCard = React.createClass({
                 </div>
             )
         }
-    },
+    };
 
-    detail() {
+    detail = () => {
         const { isExpanded, detail } = this.props;
 
         return isExpanded ? (
@@ -189,7 +188,7 @@ const MediaCard = React.createClass({
                 { detail }
             </div>
         ) : null;
-    },
+    };
 
     render() {
         const {
@@ -242,9 +241,9 @@ const MediaCard = React.createClass({
                 { this.detail() }
             </div>
         )
-    },
+    }
 
-    styles() {
+    styles = () => {
         let style = {};
 
         // card style
@@ -361,7 +360,7 @@ const MediaCard = React.createClass({
         };
 
         return style
-    }
-});
+    };
+}
 
 export default MediaCard

--- a/src/MediaCardGroup.js
+++ b/src/MediaCardGroup.js
@@ -27,9 +27,10 @@ const scroll = Scroll.animateScroll;
 /**
  * MediaCardGroup is a wrapper for MediaCards that helps to manage opening and closing, scroll animation, and stagger animation of MediaCards as children.
 */
-const MediaCardGroup = React.createClass({
-    displayName: "MediaCardGroup",
-    propTypes: {
+class MediaCardGroup extends React.Component {
+    static displayName = "MediaCardGroup";
+
+    static propTypes = {
         /**
         * If true the stagger animation is enabled
         */
@@ -38,37 +39,33 @@ const MediaCardGroup = React.createClass({
         * If true auto scrolling when card is expaned is disabled
         */
         noScroll: PropTypes.bool
-    },
+    };
 
-    getDefaultProps() {
-        return {
-            stagger: false,
-            noScroll: false,
-        }
-    },
+    static defaultProps = {
+        stagger: false,
+        noScroll: false,
+    };
 
-    getInitialState() {
-        return {
-            expanded: null
-        }
-    },
+    state = {
+        expanded: null
+    };
 
     componentDidMount() {
         document.addEventListener('click', this.handleDocumentClick, false);
-    },
+    }
 
     componentWillUnmount() {
         document.removeEventListener('click', this.handleDocumentClick, false);
-    },
+    }
 
-    handleDocumentClick(e) {
+    handleDocumentClick = (e) => {
         let cards = this.refs.root;
         if (!cards.contains(e.target)) {
             this.setState({ expanded: null });
             }
-    },
+    };
 
-    onExpand(el) {
+    onExpand = (el) => {
         let scrollAmount = this.state.expanded ?
           -40 : 40;
         if ( !this.props.noScroll ) {
@@ -81,7 +78,7 @@ const MediaCardGroup = React.createClass({
         this.setState({
             expanded
         })
-    },
+    };
 
     render() {
         const { stagger } = this.props;
@@ -114,7 +111,7 @@ const MediaCardGroup = React.createClass({
             </div>
         );
     }
-});
+}
 
 
 

--- a/src/MeterGauge.js
+++ b/src/MeterGauge.js
@@ -8,11 +8,10 @@ const v = variables;
 /**
 * A MeterGauge is used to depict a percentage of a known quantity. A common use in Troposphere is to show how much of a total resource a user HAS consumed or WILL consume. In the case that a MeterGauge is showing how much of a known quantity a user WILL consume, in a form for example, an after value can be passed in addition to the start value.
 */
-const MeterGauge =React.createClass({
+class MeterGauge extends React.Component {
+    static displayName = "MeterGauge";
 
-    displayName: "MeterGauge",
-
-    propTypes: {
+    static propTypes = {
         /**
          * The first bar value treated as percentage of total.
          */
@@ -33,19 +32,17 @@ const MeterGauge =React.createClass({
          * Text version of data.
          */
         data: PropTypes.string,
-    },
+    };
 
-    getDefaultProps() {
-        return {
-            startValue: 0,
-            afterValue: 0,
-            alertMessage: "",
-            label: "",
-            data: "",
-        }
-    },
+    static defaultProps = {
+        startValue: 0,
+        afterValue: 0,
+        alertMessage: "",
+        label: "",
+        data: "",
+    };
 
-    isOver() {
+    isOver = () => {
         const {
             startValue,
             afterValue,
@@ -53,9 +50,9 @@ const MeterGauge =React.createClass({
         return (
             startValue + afterValue >= 100
         );
-    },
+    };
 
-    alert() {
+    alert = () => {
         const {
             alertMessage
         } = this.props;
@@ -65,7 +62,7 @@ const MeterGauge =React.createClass({
                 { alertMessage }
             </div>
         ) : null;
-    },
+    };
 
     render() {
         const style = this.style();
@@ -90,9 +87,9 @@ const MeterGauge =React.createClass({
                 </dl>
             </div>
         );
-    },
+    }
 
-    style() {
+    style = () => {
         let {
             startValue,
             afterValue,
@@ -158,7 +155,7 @@ const MeterGauge =React.createClass({
             barAfter,
             alertMessage
         }
-    }
-});
+    };
+}
 
 export default muiThemeable()(MeterGauge);

--- a/src/P.js
+++ b/src/P.js
@@ -1,23 +1,24 @@
 import React from 'react';
 import { styles, marg } from './styles';
 
-export default React.createClass({
-/**
- * P is a typography component for rendering a paragraph with the proper styles.
- */
+export default class extends React.Component {
+    /**
+     * P is a typography component for rendering a paragraph with the proper styles.
+     */
+    static displayName = "P"
     render() {
         return (
-            <p style={{ 
+            <p style={{
                     ...this.style(),
                     ...this.props.style,
-                }} 
+                }}
             >
                 { this.props.children }
             </p>
         )
-    },
+    }
 
-    style() {
+    style = () => {
         let textStyle = styles.t.body1;
 
         if ( this.props.body1 ) {
@@ -27,7 +28,7 @@ export default React.createClass({
         if ( this.props.body2 ) {
             textStyle = styles.t.body2;
         }
-        
+
         if ( this.props.subheading ) {
             textStyle = styles.t.subheading;
         }
@@ -38,11 +39,11 @@ export default React.createClass({
 
         return {
             ...textStyle,
-            maxWidth: "600px", 
+            maxWidth: "600px",
             lineHeight: "1.7",
             margin: "0px",
             marginBottom: "34px",
             ...marg(this.props),
         }
-    }
-});
+    };
+}

--- a/src/Pill.js
+++ b/src/Pill.js
@@ -5,9 +5,10 @@ import { marg, variables } from './styles';
 /**
  * A Pill is used to indicate meta data like number of active users or if an item is featured or recommended. It is sort of like a badge but smaller to fit under a title or in the footer of a card.
  */
-export default React.createClass({
-    displayName: "Pill",
-    propTypes: {
+export default class extends React.Component {
+    static displayName = "Pill";
+
+    static propTypes = {
         /**
          *The background color.
          */
@@ -20,15 +21,13 @@ export default React.createClass({
          *The text that is displayed, can optionally pass an icon here and style if not MUI or CY-UI.
          */
         children: PropTypes.node,
-    },
+    };
 
-    getDefaultProps() {
-        return {
-            color: variables.c.grey.xDark
-        }
-    },
+    static defaultProps = {
+        color: variables.c.grey.xDark
+    };
 
-    Icon() {
+    Icon = () => {
         const { icon, color } = this.props;
         if (icon) {
             return (
@@ -41,7 +40,7 @@ export default React.createClass({
                 })
             )
         }
-    },
+    };
 
     render() {
         const style = this.style();    
@@ -55,9 +54,9 @@ export default React.createClass({
                 </span>
             </span>
         )
-    },
+    }
 
-    style() {
+    style = () => {
         const { color } = this.props;
         return {
             wrapper: {
@@ -79,5 +78,5 @@ export default React.createClass({
                 background: color,
             }
         }
-    },
-});
+    };
+}

--- a/src/ProgressAvatar.js
+++ b/src/ProgressAvatar.js
@@ -8,9 +8,10 @@ import { Avatar, CircularProgress } from 'material-ui';
 /**
  * ProgressAvatar can be used in place of MUI's Avatar as a clear way to inform the user that a process is taking place on that item as well as what percentage of that process is finished without taking up valuable real estate and leveraging Avatar being a visual anchor for the item.
  */
-const ProgressAvatar = React.createClass({
-    displayName: "ProgressAvatar",
-    propTypes: {
+class ProgressAvatar extends React.Component {
+    static displayName = "ProgressAvatar";
+
+    static propTypes = {
         /**
          * Optionally use an image source.
          */
@@ -31,14 +32,12 @@ const ProgressAvatar = React.createClass({
          * The percentage of progress.
          */
         percent: PropTypes.number,
-    },
+    };
 
-    getDefaultProps() {
-        return {
-            size: 40,
-            thickness: 3,
-        }
-    },
+    static defaultProps = {
+        size: 40,
+        thickness: 3,
+    };
 
     render() {
         let {
@@ -108,7 +107,7 @@ const ProgressAvatar = React.createClass({
                 </div>
             </Div>
         );
-    },
-});
+    }
+}
 
 export default muiThemeable()(ProgressAvatar);

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -12,9 +12,10 @@ import { styles, pad, marg } from './styles';
 /**
  * The SearchBar is used for searches. It has an active state that helps to inform the user a search is affecting the list in question. An optional onClear prop allows the query to be cleared when the user presses the clear button.
  */
-const SearchBar = React.createClass({
-    displayName: "SearchBar",
-    propTypes: {
+class SearchBar extends React.Component {
+    static displayName = "SearchBar";
+
+    static propTypes = {
         /**
          * The current value or query.
          */
@@ -31,15 +32,13 @@ const SearchBar = React.createClass({
          * Callback when clear button is pressed. Note, no clear button renders if not set.
          */
         onClear: PropTypes.func,
-    },
+    };
 
-    getDefaultProps() {
-        return {
-            placeholder: "Search"
-        }
-    },
+    static defaultProps = {
+        placeholder: "Search"
+    };
 
-    styleSheet() {
+    styleSheet = () => {
         const size = { pl: 2, pr: 2 }
         return createStyleSheet('Search',
             theme => ({
@@ -74,14 +73,14 @@ const SearchBar = React.createClass({
                 }
             }
         ))
-    },
+    };
 
     componentWillMount() {
         const { muiTheme } = this.props;
 
         this.classes = getStyleManager(muiTheme)
             .render(this.styleSheet());
-    },
+    }
 
     render() {
         const {
@@ -122,6 +121,6 @@ const SearchBar = React.createClass({
             </div>
         );
     }
-});
+}
 
 export default muiThemeable()(SearchBar);

--- a/src/Section.js
+++ b/src/Section.js
@@ -1,10 +1,10 @@
 import React, { PropTypes } from 'react';
 import { marg, pad } from './styles';
 
-const Section = React.createClass({
-/**
- * Section is a layout primitive.
- */
+class Section extends React.Component {
+    /**
+     * Section is a layout primitive.
+     */
 
     render() {
         return (
@@ -12,9 +12,9 @@ const Section = React.createClass({
                 { this.props.children }
             </section>
         );
-    },
+    }
 
-    styles() {
+    styles = () => {
         let displayType = (this.props.flex) ?
             { display: "flex" } :
             { display: "block" };
@@ -26,8 +26,8 @@ const Section = React.createClass({
             ...pad(this.props),
             ...this.props.styles,
         }
-    },
-});
+    };
+}
 
 Section.propTypes = {
     className: PropTypes.string,

--- a/src/SubHeader.js
+++ b/src/SubHeader.js
@@ -10,9 +10,10 @@ import Title from './Title';
 /**
  * SubHeader is the contextual header located at the top of a sub-view. A Sub-view is a view that one would navigate to from a main-view. For example clicking on a list item might open a sub-view detail of that list item. The SubHeader has a back button to navigate back to the main-view and some top level controls or actions for the particular sub-view.
  */
-const SubHeader = React.createClass({
-    displayName: "SubHeader",
-    propTypes: {
+class SubHeader extends React.Component {
+    static displayName = "SubHeader";
+
+    static propTypes = {
         /**
          * The name of the view.
          */
@@ -29,9 +30,9 @@ const SubHeader = React.createClass({
          * Callback when the back button is pressed.
          */
         onBack: PropTypes.func,
-    },
+    };
 
-    renderOptionGroup() {
+    renderOptionGroup = () => {
         let { quickActions, menuItems } = this.props;
         let style = this.style();
 
@@ -61,7 +62,7 @@ const SubHeader = React.createClass({
                 </div>
             )
         }
-    },
+    };
 
     render() {
         let { name, onBack } = this.props;
@@ -86,9 +87,9 @@ const SubHeader = React.createClass({
                 { this.renderOptionGroup() }
             </div>
         );
-    },
+    }
 
-    style() {
+    style = () => {
         return {
             header: {
                 position: "relative",
@@ -114,7 +115,7 @@ const SubHeader = React.createClass({
                 alignItems: "center",
             }
         };
-    },
-});
+    };
+}
 
 export default SubHeader;

--- a/src/Title.js
+++ b/src/Title.js
@@ -1,10 +1,10 @@
 import React, { PropTypes } from 'react';
 import { styles, marg, pad } from './styles';
 
-const Title = React.createClass({
-/**
- * Title is a typography element for rendering titles with the proper markup and styles
- */
+class Title extends React.Component {
+    /**
+     * Title is a typography element for rendering titles with the proper markup and styles
+     */
 
     render() {
         let HTag = 'h1';
@@ -26,9 +26,9 @@ const Title = React.createClass({
                     { this.props.children }
                 </HTag>
             )
-    },
+    }
 
-    styles() {
+    styles = () => {
         let color = this.props.color;
 
         let fontStyle;
@@ -76,8 +76,8 @@ const Title = React.createClass({
             ...marg( this.props ),
             ...pad( this.props ),
         }
-    }
-});
+    };
+}
 
 Title.propTypes = {
     className: PropTypes.string,

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -4,8 +4,8 @@ import * as colors from 'material-ui/styles/colors';
 /**
 * A Tooltip is used to show on demand information about an element, usually an action. Is initially hidden to keep the UI clean but can be shown by hovering over the element in question.
 */
-export default React.createClass({
-    propTypes: {
+export default class extends React.Component {
+    static propTypes = {
         /**
         * Text that shows on tooltip
         */
@@ -18,46 +18,44 @@ export default React.createClass({
         * The element that shows Tooltip on hover and anchors the toopltip's direction
         */
         children: React.PropTypes.node.isRequired
-    },
+    };
 
-    displayName: "Tooltip",
+    static displayName = "Tooltip";
 
-    getInitialState() {
-        return ({
-            showTooltip: false,
-        })
-    },
+    state = {
+        showTooltip: false,
+    };
 
-    showTooltip() {
+    showTooltip = () => {
         if (this.props.message) {
             this.setState({
                 showTooltip: true,
             });
         }
-    },
+    };
 
-    hideTooltip() {
+    hideTooltip = () => {
         this.setState({
             showTooltip: false,
         });
-    },
+    };
 
-    onMouseEnter() {
+    onMouseEnter = () => {
         if (!this.props.isDisabled) {
             this.showTooltip();
         }
-    },
+    };
 
-    onMouseLeave() {
+    onMouseLeave = () => {
         this.hideTooltip();
-    },
+    };
 
-    onTouch() {
+    onTouch = () => {
         this.props.onTouch();
         setTimeout( ()=> this.hideTooltip(), 2000);
-    },
+    };
 
-    directionStyle() {
+    directionStyle = () => {
         let direction = this.props.direction;
         const offset = "calc(100% + 10px)";
         switch(direction) {
@@ -87,9 +85,9 @@ export default React.createClass({
                     bottom: offset,
                 }
         }
-    },
+    };
 
-    style() {
+    style = () => {
         const { showTooltip } = this.state;
         const x = showTooltip ? 1 : 0;
         return {
@@ -111,7 +109,7 @@ export default React.createClass({
                 transition: "opacity ease .2s, transform ease .2s"
             }
         }
-    },
+    };
 
     render() {
         return (
@@ -134,4 +132,4 @@ export default React.createClass({
                 </span>
         )
     }
-});
+}

--- a/src/VerticalMenu.js
+++ b/src/VerticalMenu.js
@@ -9,9 +9,10 @@ import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 
 Because VerticalMenus should appear to the top right corner this component defaults to opening from the right and down but this behavior can be overridden using `anchorOrigin` and `targetOrigin`. See  [Material-UI's IconMenu](http://www.material-ui.com/#/components/icon-menu) for better documentation.
  */
-const VerticalMenu = React.createClass({
-    displayName: "VerticalMenu",
-    propTypes: {
+class VerticalMenu extends React.Component {
+    static displayName = "VerticalMenu";
+
+    static propTypes = {
         /**
          * This is the point on the icon where the menu targetOrigin will attach. Options: vertical: [top, center, bottom] horizontal: [left, middle, right].
          */
@@ -24,17 +25,17 @@ const VerticalMenu = React.createClass({
          * Should be used to pass MenuItem components.
          */
         children: PropTypes.node,
-    },
-    getDefaultProps() {
-        return {
-            anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
-            targetOrigin: { horizontal: 'right', vertical: 'top' }
-        }
-    },
-    onTouch(e) {
+    };
+
+    static defaultProps = {
+        anchorOrigin: { horizontal: 'right', vertical: 'bottom' },
+        targetOrigin: { horizontal: 'right', vertical: 'top' }
+    };
+
+    onTouch = (e) => {
         e.stopPropagation();
         e.preventDefault();
-    },
+    };
 
     render() {
         const {
@@ -54,7 +55,7 @@ const VerticalMenu = React.createClass({
                 targetOrigin={ targetOrigin }
             />
         )
-    },
-});
+    }
+}
 
 export default VerticalMenu;

--- a/src/utils/ButtonGroup.js
+++ b/src/utils/ButtonGroup.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { marg } from '../styles';
 import ClearFix from './ClearFix';
 
-export default React.createClass({
+export default class extends React.Component {
+    static displayName = "ButtonGroup"
     render() {
         const { children, pullR, pullL } = this.props;
 
@@ -38,4 +39,4 @@ export default React.createClass({
             </ClearFix>
         )
     }
-});
+}

--- a/src/utils/TagGroup.js
+++ b/src/utils/TagGroup.js
@@ -3,9 +3,8 @@ import { marg, styles } from '../styles';
 
 const s = styles;
 
-const TagGroup = React.createClass({
-
-    listItems(item) {
+class TagGroup extends React.Component {
+    listItems = (item) => {
         return (
             <li 
                 key={ item.props.children.toString() }
@@ -14,7 +13,7 @@ const TagGroup = React.createClass({
                 { item }
             </li>
         )
-    },
+    };
 
     render() {
         return (
@@ -22,9 +21,9 @@ const TagGroup = React.createClass({
                 { this.props.children.map(this.listItems) }
             </ul>
         );
-    },
+    }
 
-    styles() {
+    styles = () => {
         return {
 
             li: {
@@ -36,9 +35,8 @@ const TagGroup = React.createClass({
                 ...s.u.inlineUl,
             }
         }
-    },
-
-});
+    };
+}
 
 TagGroup.propTypes = {
     className: PropTypes.string,

--- a/src/utils/hoverable.js
+++ b/src/utils/hoverable.js
@@ -1,37 +1,37 @@
 import React from 'react';
 
 const hoverable = (component) => {
-    return React.createClass({
-        getInitialState() {
-            return {
-                isHovered: false
-            }
-        },
+    return class extends React.Component {
+        static displayName = "Hoverable"
 
-        onMouseEnter() {
+        state = {
+            isHovered: false
+        };
+
+        onMouseEnter = () => {
             this.setState({
                 isHovered: true
             });
-        },
+        };
 
-        onMouseLeave() {
+        onMouseLeave = () => {
             this.setState({
                 isHovered: false
             });
-        },
+        };
 
         render() {
             const { isHovered } = this.state;
             return React.createElement(
                 component,
-                { 
+                {
                     isHovered,
                     onMouseEnter: this.onMouseEnter,
                     onMouseLeave: this.onMouseLeave,
                     ...this.props,
                 });
         }
-    });
+    };
 }
 
 export default hoverable;


### PR DESCRIPTION
For the sake of aligning with the react community and being easier for new devs to contribute all instances of `createClass` have been switched over to using es6 classes instead.