### PR TITLE
Problem: README guide instructions out-of-date

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -37,10 +37,10 @@ npm i
 npm run build
 
 # From within guide (separate terminal)
-npm run serve
+npm run start
 
 # Navigate to url
-open http://localhost:8080
+open http://localhost:3000
 ```
 
 #### Publishing


### PR DESCRIPTION
This includes an update on the command to start webpack-dev-server and the port it will be available on.