### PR TITLE
Use PropTypes from 'prop-types' package instead of React.PropTypes

### DIFF
--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -8003,12 +8003,11 @@
       "integrity": "sha1-EInxDdxH0M+tLERQt980xTukU7Q="
     },
     "react-scroll": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.6.4.tgz",
-      "integrity": "sha512-hBJlqX+ig3Lw+JN2w8jFJQG1VWLxcVHfb6DzlMU67rC1clyyei5L6DpjjQoafZuvqOH/jOKWanCyN7yaMRyUTg==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.0.17.tgz",
+      "integrity": "sha1-2guoVA5ljEgag03Ljb+iJmEmFvI=",
       "requires": {
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "object-assign": "4.1.1"
       }
     },
     "react-tap-event-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3282,16 +3282,22 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mkdirp-promise": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+      "requires": {
+        "mkdirp": "0.5.1"
       }
     },
     "ms": {

--- a/src/ButtonMenu.js
+++ b/src/ButtonMenu.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Div from './Div';
 import RaisedButton from 'material-ui/RaisedButton';
 import Popover from 'material-ui/Popover';
@@ -16,35 +17,35 @@ export default class extends React.Component {
         /**
          * Override the inline-styles of the root element.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Icon to render in button.
          */
-        buttonIcon: React.PropTypes.element,
+        buttonIcon: PropTypes.element,
         /**
          * Text on the button.
          */
-        buttonLabel: React.PropTypes.string,
+        buttonLabel: PropTypes.string,
         /**
          * If true the button uses the primary theme color.
          */
-        primary: React.PropTypes.bool,
+        primary: PropTypes.bool,
         /**
          * If true the button uses the secondary theme color.
          */
-        secondary: React.PropTypes.bool,
+        secondary: PropTypes.bool,
         /**
          * If true the button will be disabled.
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * This is the point on the anchor where the popover's targetOrigin will attach to. Options: vertical: [top, center, bottom] horizontal: [left, middle, right].
          */
-        anchorOrigin: React.PropTypes.object,
+        anchorOrigin: PropTypes.object,
         /**
          * This is the point on the popover which will attach to the anchor's origin. Options: vertical: [top, center, bottom] horizontal: [left, middle, right].
          */
-        targetOrigin: React.PropTypes.object,
+        targetOrigin: PropTypes.object,
     };
 
     state = {

--- a/src/Div.js
+++ b/src/Div.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { marg, pad } from './styles';
 
 class Div extends React.Component {
@@ -7,7 +8,7 @@ class Div extends React.Component {
      */
     render() {
         return (
-            <div 
+            <div
                 id={ this.props.id }
                 style={ this.styles() }
             >

--- a/src/Identity.js
+++ b/src/Identity.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { marg } from './styles';
 import P from './P';
 import Title from './Title';
@@ -68,19 +69,19 @@ Identity.propTypes = {
     /**
      * The first line of text, usually a name.
      */
-    primaryText: React.PropTypes.string,
+    primaryText: PropTypes.string,
     /**
      * The second line of text, usually a date or caption.
      */
-    secondaryText: React.PropTypes.string,
+    secondaryText: PropTypes.string,
     /**
      * Expects MUI's Avatar.
      */
-    image: React.PropTypes.element,
+    image: PropTypes.element,
     /**
      * If true Identity is rendered larger.
      */
-    lg: React.PropTypes.bool,
+    lg: PropTypes.bool,
 };
 
 Identity.displayName = "Identity";

--- a/src/InfoBlock.js
+++ b/src/InfoBlock.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import InformationIcon from "material-ui/svg-icons/action/info";
 import WarningIcon from "material-ui/svg-icons/alert/warning";
 import P from "./P";
@@ -14,11 +15,11 @@ export default class extends React.Component {
         /**
          * The information text that will be displayed.
          */
-        text: React.PropTypes.string,
+        text: PropTypes.string,
         /**
          * Show the warning icon over the default info icon
          */
-        warning: React.PropTypes.bool,
+        warning: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -48,7 +49,7 @@ export default class extends React.Component {
                     display: "flex",
                     ...marg(this.props)
                 }}
-            > 
+            >
                 { this.icon() }
                 <P mb={ 0 }>
                     { this.props.text }

--- a/src/Section.js
+++ b/src/Section.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { marg, pad } from './styles';
 
 class Section extends React.Component {

--- a/src/Title.js
+++ b/src/Title.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { styles, marg, pad } from './styles';
 
 class Title extends React.Component {

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import * as colors from 'material-ui/styles/colors';
 
 /**
@@ -9,15 +10,15 @@ export default class extends React.Component {
         /**
         * Text that shows on tooltip
         */
-        message: React.PropTypes.string.isRequired,
+        message: PropTypes.string.isRequired,
         /**
         * The direction of the element Tooltip will open from. Expects one of: "right", "bottom", "left", "top".
         */
-        direction: React.PropTypes.oneOf(['right', 'left', 'top', 'bottom']),
+        direction: PropTypes.oneOf(['right', 'left', 'top', 'bottom']),
         /**
         * The element that shows Tooltip on hover and anchors the toopltip's direction
         */
-        children: React.PropTypes.node.isRequired
+        children: PropTypes.node.isRequired
     };
 
     static displayName = "Tooltip";

--- a/src/utils/TagGroup.js
+++ b/src/utils/TagGroup.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { marg, styles } from '../styles';
 
 const s = styles;
@@ -6,7 +7,7 @@ const s = styles;
 class TagGroup extends React.Component {
     listItems = (item) => {
         return (
-            <li 
+            <li
                 key={ item.props.children.toString() }
                 style={ this.styles().li }
             >


### PR DESCRIPTION
This PR replaces all uses of `React.PropTypes` with the `PropTypes` implementation from the `prop-types` package. This makes it compatible with React v16.

Lines like this:

```jsx
import React, { PropTypes } from 'react'
...
Component.propTypes = {
  foo: React.PropTypes.string.isRequired,
  foo: PropTypes.string.isRequired,
}
```

Now becomes lines like these:

```jsx
import React from 'react';
import PropTypes from 'prop-types';

...
Component.propTypes = {
  foo: PropTypes.string.isRequired,
  foo: PropTypes.string.isRequired,
}
```