### PR TITLE
Build ES5 and ES6 versions of library for tree-shaking

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,35 @@
 {
-    "presets": ["es2015","stage-2", "react"],
+    "presets": [
+        "es2015",
+        "react",
+        "stage-2"
+    ],
+    "plugins": [],
+    "env": {
+        "cjs": {
+            "presets": [
+                ["es2015", {
+                    "modules": "commonjs"
+                }],
+                "react",
+                "stage-2"
+            ]
+        },
+        "es": {
+            "presets": [
+                ["es2015", {
+                    "modules": false
+                }],
+                "react",
+                "stage-2"
+            ]
+        },
+        "test": {
+            "presets": [
+                "es2015",
+                "react",
+                "stage-2"
+            ]
+        }
+    }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
-build
+lib
+es
 
 # Ignore temp files
 *.swp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,8 +1147,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -1167,7 +1166,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1285,8 +1283,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -1754,8 +1751,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.1.3",
@@ -2680,7 +2676,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2788,7 +2783,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -2797,8 +2791,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inline-style-prefixer": {
       "version": "3.0.8",
@@ -3278,7 +3271,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -3381,7 +3373,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -3445,8 +3436,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -3904,7 +3894,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -4174,8 +4163,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,59 +1,59 @@
 {
-  "name": "cyverse-ui",
-  "version": "0.0.3",
-  "description": "A React UI library for the CyVerse tool set",
-  "main": "./index.js",
-  "keywords": [
-    "react",
-    "react-component",
-    "material design",
-    "material-ui"
-  ],
-  "scripts": {
-    "build": "babel -d ./build src; cp package.json build/",
-    "lint": "eslint -c .eslintrc --ext .jsx,.js --no-eslintrc src",
-    "watch": "babel -w -d . src"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/cyverse/cyverse-ui.git"
-  },
-  "author": "CyVerse",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/cyverse/cyverse-ui/issues"
-  },
-  "homepage": "https://github.com/cyverse/cyverse-ui#readme",
-  "peerDependencies": {
-    "material-ui": ">= 0.17.1 < 1.0.0",
-    "react": ">= 15.0.1 < 17.0.0",
-    "react-tap-event-plugin": ">= 2.0.1 < 4.0.0"
-  },
-  "dependencies": {
-    "jss": "^7.1.5",
-    "jss-preset-default": "^2.0.0",
-    "jss-theme-reactor": "^0.11.1",
-    "mkdirp-promise": "^5.0.1",
-    "prop-types": "^15.5.10",
-    "react-css-stagger": "0.0.5",
-    "react-ink": "6.2.0",
-    "react-scroll": "^1.6.7"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.9.0",
-    "babel-core": "^6.2.1",
-    "babel-eslint": "^6.0.0",
-    "babel-preset-es2015": "^6.1.18",
-    "babel-preset-react": "^6.1.18",
-    "babel-preset-stage-0": "^6.5.0",
-    "babel-preset-stage-2": "^6.5.0",
-    "eslint": "^2.13.*",
-    "eslint-plugin-react": "^5.1.1",
-    "material-ui": "~0.19.4",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-docgen": "^2.17.0",
-    "react-tap-event-plugin": "^3.0.1",
-    "write-json": "^1.0.1"
-  }
+    "name": "cyverse-ui",
+    "version": "1.0.0",
+    "description": "A React UI library for the CyVerse tool set",
+    "repository": "cyverse/cyverse-ui",
+    "homepage": "https://github.com/cyverse/cyverse-ui#readme",
+    "bugs": "https://github.com/cyverse/cyverse-ui/issues",
+    "license": "BSD-3-Clause",
+    "author": "CyVerse",
+    "keywords": [
+        "react",
+        "react-component",
+        "material design",
+        "material-ui"
+    ],
+    "main": "lib/index.js",
+    "module": "es/index.js",
+    "scripts": {
+        "build": "npm run clean && npm run build:cjs && npm run build:es",
+        "build:cjs": "BABEL_ENV=cjs babel src --out-dir lib",
+        "build:es": "BABEL_ENV=es babel src --out-dir es",
+        "clean": "rimraf lib && rimraf es",
+        "lint": "eslint -c .eslintrc --ext .jsx,.js --no-eslintrc src",
+        "prepublish": "npm run build"
+    },
+    "dependencies": {
+        "jss": "^7.1.5",
+        "jss-preset-default": "^2.0.0",
+        "jss-theme-reactor": "^0.11.1",
+        "mkdirp-promise": "^5.0.1",
+        "prop-types": "^15.5.10",
+        "react-css-stagger": "0.0.5",
+        "react-ink": "6.2.0",
+        "react-scroll": "^1.6.7"
+    },
+    "devDependencies": {
+        "babel-cli": "^6.9.0",
+        "babel-core": "^6.2.1",
+        "babel-eslint": "^6.0.0",
+        "babel-preset-es2015": "^6.1.18",
+        "babel-preset-react": "^6.1.18",
+        "babel-preset-stage-0": "^6.5.0",
+        "babel-preset-stage-2": "^6.5.0",
+        "eslint": "^2.13.*",
+        "eslint-plugin-react": "^5.1.1",
+        "material-ui": "~0.19.4",
+        "react": "^16.0.0",
+        "react-dom": "^16.0.0",
+        "react-docgen": "^2.17.0",
+        "react-tap-event-plugin": "^3.0.1",
+        "rimraf": "^2.6.2",
+        "write-json": "^1.0.1"
+    },
+    "peerDependencies": {
+        "material-ui": ">= 0.17.1 < 1.0.0",
+        "react": ">= 15.0.1 < 17.0.0",
+        "react-tap-event-plugin": ">= 2.0.1 < 4.0.0"
+    }
 }


### PR DESCRIPTION
This PR sets up the library to generate _two_ build directories; `lib` and `es`.

### Explanation of Build Directories
The `lib` directory contains fully transpiled 100% ES5 compatible code.

The `es` directory contains ES5 code _except_ for the imports and exports, which are left as ES6 statements.

This step is required to support tree-shaking, as the consuming build system (e.g. Webpack) needs to be able to statically analyze the files to know which ones to include in the final build. The adopted practice for doing this is generating multiple build directories, and then providing links to them from the `package.json` file.

The `main` entry point is used to specify the location of the ES5 code, which will work with all JavaScript applications. A second entry point called `module` has been adopted to provide the location of the ES6 code, which is only compatible with projects that know how to parse it, making it an "opt-in" behavior for ES6-compatible projects.

### Changes to `package.json`
This PR also makes the following changes to the package.json file:

1. Modifies the spacing in the `package.json` file to be 4 spaces, per coding conventions specified in `.editorconfig` and used elsewhere in the project.

2. Changes the `version` to be `1.0.0`, to reflect the currently published version.

3. Includes a `module` entry point which points to the location of the ES6 code (in the `es` directory)

4. Re-organizes the order of the fields, to group the dependencies together at the bottom, and pushing all the metadata to the top (instead of being interlaced, making it easier to parse and locate what you're looking for).

5. Uses the allowed "simple" syntax instead of object syntax where applicable (repository & bugs fields) to make the file less verbose.

6. Adds a `clean` script to remove the build directories.

