### PR TITLE
Improvements to MeterGauge

### DIFF
--- a/guide/src/componentDocs/BarGraph/BarGraphDoc.js
+++ b/guide/src/componentDocs/BarGraph/BarGraphDoc.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { P } from 'cyverse-ui';
+import { Figure, ComponentDoc, CodeBlock } from '../../components';
+
+import BarGraphEx from './BarGraphEx';
+import BarGraphExCode from '!raw-loader!./BarGraphEx';
+import { parse } from 'react-docgen';
+import BarGraph from '!raw-loader!cyverse-ui/BarGraph';
+const meta = parse(BarGraph);
+
+class BarGraphDoc extends React.Component {
+    render() {
+        return (
+            <ComponentDoc meta={ meta } >
+                <Figure caption={ 'BarGraph Example' } >
+                    <BarGraphEx/>
+                    <CodeBlock text={ BarGraphExCode } />
+                </Figure>
+            </ComponentDoc>
+        )
+    }
+}
+
+export default BarGraphDoc;

--- a/guide/src/componentDocs/BarGraph/BarGraphEx.js
+++ b/guide/src/componentDocs/BarGraph/BarGraphEx.js
@@ -1,0 +1,22 @@
+import React from "react";
+import * as colors from "material-ui/styles/colors";
+import Paper from "material-ui/Paper";
+import { BarGraph } from "cyverse-ui";
+import { pad, marg } from "cyverse-ui/styles";
+
+const BarGraphEx = props => (
+    <Paper
+        style={{
+            ...marg({ mb: 4 }),
+            ...pad({ p: 3 })
+        }}
+    >
+        <BarGraph
+            startValue={40}
+            afterValue={10}
+            barColor={colors.lightBlue400}
+        />
+    </Paper>
+);
+
+export default BarGraphEx;

--- a/guide/src/componentDocs/MeterGauge/MeterGaugeEx.js
+++ b/guide/src/componentDocs/MeterGauge/MeterGaugeEx.js
@@ -14,8 +14,8 @@ export default class extends React.Component {
 
     data = () => {
         const { used, willUse, totalAllowed } = this.state;
-        const startValue = (used / totalAllowed) * 100;
-        const afterValue = (willUse / totalAllowed) * 100;
+        const startValue = Math.round((used / totalAllowed) * 100);
+        const afterValue = Math.round((willUse / totalAllowed) * 100);
         return {
             startValue,
             afterValue,
@@ -60,6 +60,15 @@ export default class extends React.Component {
                         data={ `Will total ${dataTotal}kg of ${totalAllowed}kg` }
                         startValue={startValue}
                         afterValue={afterValue}
+                        alertMessage="Hey, let's not get greedy"
+                    />
+                    <MeterGauge
+                        mb={ 3 }
+                        compact
+                        hideLabel
+                        label="Compact"
+                        data={ `%${startValue + afterValue}` }
+                        startValue={startValue + afterValue}
                         alertMessage="Hey, let's not get greedy"
                     />
                     <div style={ styles.t.label } >

--- a/guide/src/componentDocs/MeterGauge/MeterGaugeEx.js
+++ b/guide/src/componentDocs/MeterGauge/MeterGaugeEx.js
@@ -67,7 +67,7 @@ export default class extends React.Component {
                         compact
                         hideLabel
                         label="Compact"
-                        data={ `%${startValue + afterValue}` }
+                        data={ `${startValue + afterValue}%` }
                         startValue={startValue + afterValue}
                         alertMessage="Hey, let's not get greedy"
                     />

--- a/guide/src/componentDocs/index.js
+++ b/guide/src/componentDocs/index.js
@@ -24,3 +24,4 @@ export { default as ActionGroupDoc } from './ActionGroup/ActionGroupDoc';
 export { default as CheckableAvatarDoc } from './CheckableAvatar/CheckableAvatarDoc';
 export { default as SummaryTextDoc } from './SummaryText/SummaryTextDoc';
 export { default as ElementDoc } from './Element/ElementDoc';
+export { default as BarGraphDoc } from './BarGraph/BarGraphDoc';

--- a/src/BarGraph.js
+++ b/src/BarGraph.js
@@ -1,0 +1,91 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { createStyleSheet } from "jss-theme-reactor";
+import getStyleManager from "./styles/getStyleManager";
+import muiThemeable from "material-ui/styles/muiThemeable";
+import * as colors from "material-ui/styles/colors";
+import Element from "./Element";
+
+// Define static styles here.
+// Each key of the returned object will be available as a className below.
+const styleSheet = theme =>
+    createStyleSheet("BarGraph", theme => ({
+        wrapper: {
+            display: "flex",
+            background: colors.grey100
+        },
+        barBefore: {
+            transition: "flex-basis ease .3s",
+            flexShrink: "0",
+            maxWidth: "100%"
+        },
+        barAfter: {
+            transition: "flex-basis ease .3s",
+            opacity: ".5"
+        }
+    }));
+/**
+ * BarGraph is used to show a percentage of a whole.
+ */
+const BarGraph = ({
+    startValue,
+    afterValue,
+    barColor,
+    compact,
+    muiTheme
+}) => {
+    // Generate classes object and render corresponding style definitions in header.
+    const classes = getStyleManager(muiTheme).render(styleSheet());
+
+    const style = {
+        wrapper: {
+            height: compact ? "5px" : "10px"
+        },
+        barBefore: {
+            flexBasis: startValue + "%",
+            background: barColor
+        },
+        barAfter: {
+            flexBasis: afterValue + "%",
+            background: barColor
+        }
+    };
+    return (
+        <Element
+            display="flex"
+            style={style.wrapper}
+            className={classes.wrapper}
+        >
+            <div
+                style={style.barBefore}
+                className={classes.barBefore}
+            />
+            <div
+                style={style.barAfter}
+                className={classes.barAfter}
+            />
+        </Element>
+    );
+};
+BarGraph.displayName = "BarGraph";
+
+BarGraph.propTypes = {
+    /**
+     * The number representing the primary percentage of a whole used
+     */
+    startValue: PropTypes.number,
+    /**
+     * The number representing the secondary percentage of a whole used. Typically a projected value after an action is taken.
+     */
+    afterValue: PropTypes.number,
+    /**
+     * The color of the bar representing the percentage of the whole used. The after value will be a lighter version of this color.
+     */
+    barColor: PropTypes.string,
+    /**
+     * Wether the BarGraph is compact or regular size
+     */
+    compact: PropTypes.bool,
+};
+
+export default muiThemeable()(BarGraph);

--- a/src/MeterGauge.js
+++ b/src/MeterGauge.js
@@ -1,10 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import muiThemeable from "material-ui/styles/muiThemeable";
-import { variables, styles, marg } from "./styles";
+import * as colors from "material-ui/styles/colors";
+import { styles, marg } from "./styles";
 import Element from "./Element";
-
-const v = variables;
+import BarGraph from "./BarGraph";
 
 /**
  * A MeterGauge is used to depict a percentage of a known quantity. A common use in Troposphere is to show how much of a total resource a user HAS consumed or WILL consume. In the case that a MeterGauge is showing how much of a known quantity a user WILL consume, in a form for example, an after value can be passed in addition to the start value.
@@ -60,49 +60,51 @@ class MeterGauge extends React.Component {
 
     render() {
         const style = this.style();
-        const { hideLabel } = this.props;
+        const {
+            hideLabel,
+            muiTheme,
+            startValue,
+            afterValue,
+            compact
+        } = this.props;
+
+        const {
+            success,
+            danger
+        } = muiTheme.palette;
+
+        const startColor = this.isOver() ? danger : success;
 
         return (
             <Element style={style.wrapper}>
                 <dl>
                     <Element
-                        hide={hideLabel}
                         tag="dt"
+                        hide={hideLabel}
                         typography="label"
-                        style={style.label}
                     >
                         {this.props.label}
                     </Element>
-
                     <dd style={style.data}>
                         <div style={style.dataText}>
                             {this.props.data}
                         </div>
-                        <div style={style.bar}>
-                            <div style={style.barBefore} />
-                            <div style={style.barAfter} />
-                        </div>
-                        {this.alert()}
+                        <BarGraph
+                            startValue={startValue}
+                            afterValue={afterValue}
+                            barColor={startColor}
+                            compact={compact}
+                        />
                     </dd>
+                    {this.alert()}
                 </dl>
             </Element>
         );
     }
 
     style = () => {
-        let {
-            startValue,
-            afterValue,
-            compact,
-            muiTheme
-        } = this.props;
-
-        const {
-            success = "green",
-            danger = "red"
-        } = muiTheme.palette;
-
-        const startColor = this.isOver() ? danger : success;
+        let { compact, muiTheme } = this.props;
+        const { danger = "red" } = muiTheme.palette;
 
         // Start styles
         const wrapper = {
@@ -110,54 +112,21 @@ class MeterGauge extends React.Component {
             height: "70px"
         };
 
-        const isCompactData = compact
-            ? {
-                  maxWidth: "60px"
-              }
-            : null;
         const data = {
-            ...isCompactData,
+            maxWidth: compact ? "60px" : "100%",
             margin: 0
         };
 
-        const isCompactDataText = compact
-            ? {
-                  textAlign: "center"
-              }
-            : null;
-
         const dataTextColor = this.isOver() ? danger : "#333333";
-
+        const dataTextAlighn = compact ? "center" : "left";
         const dataText = {
             ...styles.t.caption,
-            ...isCompactDataText,
+            textAlign: dataTextAlighn,
             color: dataTextColor,
             fontSize: "13px",
             margin: "0px 0px 3px"
         };
 
-        const label = {
-            background: "red"
-        };
-
-        const bar = {
-            display: "flex",
-            height: compact ? "5px" : "10px",
-            background: v.c.grey.light
-        };
-        const barBefore = {
-            transition: "flex-basis ease .3s",
-            flexShrink: "0",
-            maxWidth: "100%",
-            flexBasis: startValue + "%",
-            background: startColor
-        };
-        const barAfter = {
-            transition: "flex-basis ease .3s",
-            flexBasis: afterValue + "%",
-            background: startColor,
-            opacity: ".5"
-        };
         const alertMessage = {
             marginTop: "5px",
             fontSize: "12px",
@@ -167,12 +136,8 @@ class MeterGauge extends React.Component {
         // Combine Styles
         return {
             wrapper,
-            label,
             data,
             dataText,
-            bar,
-            barBefore,
-            barAfter,
             alertMessage
         };
     };

--- a/src/MeterGauge.js
+++ b/src/MeterGauge.js
@@ -1,13 +1,14 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import muiThemeable from 'material-ui/styles/muiThemeable';
-import { variables, styles, marg } from './styles';
+import React from "react";
+import PropTypes from "prop-types";
+import muiThemeable from "material-ui/styles/muiThemeable";
+import { variables, styles, marg } from "./styles";
+import Element from "./Element";
 
 const v = variables;
 
 /**
-* A MeterGauge is used to depict a percentage of a known quantity. A common use in Troposphere is to show how much of a total resource a user HAS consumed or WILL consume. In the case that a MeterGauge is showing how much of a known quantity a user WILL consume, in a form for example, an after value can be passed in addition to the start value.
-*/
+ * A MeterGauge is used to depict a percentage of a known quantity. A common use in Troposphere is to show how much of a total resource a user HAS consumed or WILL consume. In the case that a MeterGauge is showing how much of a known quantity a user WILL consume, in a form for example, an after value can be passed in addition to the start value.
+ */
 class MeterGauge extends React.Component {
     static displayName = "MeterGauge";
 
@@ -31,7 +32,7 @@ class MeterGauge extends React.Component {
         /**
          * Text version of data.
          */
-        data: PropTypes.string,
+        data: PropTypes.string
     };
 
     static defaultProps = {
@@ -39,53 +40,52 @@ class MeterGauge extends React.Component {
         afterValue: 0,
         alertMessage: "",
         label: "",
-        data: "",
+        data: ""
     };
 
     isOver = () => {
-        const {
-            startValue,
-            afterValue,
-        } = this.props;
-        return (
-            startValue + afterValue >= 100
-        );
+        const { startValue, afterValue } = this.props;
+        return startValue + afterValue >= 100;
     };
 
     alert = () => {
-        const {
-            alertMessage
-        } = this.props;
+        const { alertMessage } = this.props;
 
         return this.isOver() ? (
-            <div style={ this.style().alertMessage } >
-                { alertMessage }
+            <div style={this.style().alertMessage}>
+                {alertMessage}
             </div>
         ) : null;
     };
 
     render() {
         const style = this.style();
+        const { hideLabel } = this.props;
 
         return (
-            <div style={ style.wrapper }>
+            <Element style={style.wrapper}>
                 <dl>
-                    <dt style={ styles.t.label } >
+                    <Element
+                        hide={hideLabel}
+                        tag="dt"
+                        typography="label"
+                        style={style.label}
+                    >
                         {this.props.label}
-                    </dt>
+                    </Element>
 
-                    <dd style={{margin: "0px"}}>
-                        <div style={ style.data }>
+                    <dd style={style.data}>
+                        <div style={style.dataText}>
                             {this.props.data}
                         </div>
-                        <div style={ style.bar }>
-                            <div style={ style.barBefore }/>
-                            <div style={ style.barAfter }/>
+                        <div style={style.bar}>
+                            <div style={style.barBefore} />
+                            <div style={style.barAfter} />
                         </div>
-                        { this.alert() }
+                        {this.alert()}
                     </dd>
                 </dl>
-            </div>
+            </Element>
         );
     }
 
@@ -93,6 +93,7 @@ class MeterGauge extends React.Component {
         let {
             startValue,
             afterValue,
+            compact,
             muiTheme
         } = this.props;
 
@@ -101,60 +102,79 @@ class MeterGauge extends React.Component {
             danger = "red"
         } = muiTheme.palette;
 
-        const startColor = this.isOver() ?
-            danger : success;
-
-        const dataText = this.isOver() ?
-            danger : "#333333";
+        const startColor = this.isOver() ? danger : success;
 
         // Start styles
         const wrapper = {
             ...marg(this.props),
             height: "70px"
-        }
+        };
 
+        const isCompactData = compact
+            ? {
+                  maxWidth: "60px"
+              }
+            : null;
         const data = {
+            ...isCompactData,
+            margin: 0
+        };
+
+        const isCompactDataText = compact
+            ? {
+                  textAlign: "center"
+              }
+            : null;
+
+        const dataTextColor = this.isOver() ? danger : "#333333";
+
+        const dataText = {
             ...styles.t.caption,
-            color: dataText,
+            ...isCompactDataText,
+            color: dataTextColor,
             fontSize: "13px",
-            margin: "0px 0px 3px",
-        }
+            margin: "0px 0px 3px"
+        };
+
+        const label = {
+            background: "red"
+        };
+
         const bar = {
             display: "flex",
-            background: v.c.grey.xLight
-        }
+            height: compact ? "5px" : "10px",
+            background: v.c.grey.light
+        };
         const barBefore = {
             transition: "flex-basis ease .3s",
-            height:"10px",
-            float: "left",
             flexShrink: "0",
             maxWidth: "100%",
             flexBasis: startValue + "%",
             background: startColor
-        }
+        };
         const barAfter = {
             transition: "flex-basis ease .3s",
-            height:"10px",
-            float: "left",
             flexBasis: afterValue + "%",
             background: startColor,
-            opacity:".5"
-        }
+            opacity: ".5"
+        };
         const alertMessage = {
             marginTop: "5px",
             fontSize: "12px",
-            color: danger,
-        }
+            color: danger
+        };
 
         // Combine Styles
         return {
             wrapper,
+            label,
             data,
+            dataText,
             bar,
             barBefore,
             barAfter,
             alertMessage
-        }
+        };
     };
 }
 

--- a/src/MeterGauge.js
+++ b/src/MeterGauge.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import muiThemeable from "material-ui/styles/muiThemeable";
-import * as colors from "material-ui/styles/colors";
 import { styles, marg } from "./styles";
 import Element from "./Element";
 import BarGraph from "./BarGraph";

--- a/src/index.js
+++ b/src/index.js
@@ -30,3 +30,4 @@ export { default as CheckableAvatar } from './CheckableAvatar';
 export { default as MDBlock } from './MDBlock';
 export { default as SummaryText } from './SummaryText';
 export { default as Element } from './Element';
+export { default as BarGraph } from './BarGraph';

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -26,7 +26,6 @@ let styleVariables = {
     t: {
 
         label: {
-            display: "block",
             fontSize: "12px",
             fontWeight: "200",
             color: "rgba(0, 0, 0, 0.3)",


### PR DESCRIPTION
This PR gives MeterGauge a compact state to satisfy designs on instance cards and future designs where a compact version is required.

In addition a refactor of MeterGauge breaks it into more reusable pieces following the [Atomic pattern](http://bradfrost.com/blog/post/atomic-web-design/)

In this case the name BarGraph was used for the bar component that is used for MeterGauge this may not be the ideal name. Suggestions are welcome.

## Full and Compact Versions
<img width="407" alt="screen shot 2018-01-08 at 9 13 57 am" src="https://user-images.githubusercontent.com/7366338/34679835-629185fe-f454-11e7-94cd-09cfa6f396ee.png">

## BarGraph is used to make MeterGauge
<img width="1095" alt="screen shot 2018-01-08 at 9 14 13 am" src="https://user-images.githubusercontent.com/7366338/34679880-8704f0ba-f454-11e7-9735-35d52e3873f2.png">

