### PR TITLE
Problem: dependency `marked` less 0.3.9 has known vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cyverse-ui",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3350,9 +3350,9 @@
       }
     },
     "marked": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
-      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
     },
     "material-ui": {
       "version": "0.19.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyverse-ui",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A React UI library for the CyVerse tool set",
   "repository": "cyverse/cyverse-ui",
   "homepage": "https://github.com/cyverse/cyverse-ui#readme",
@@ -33,7 +33,7 @@
     "jss": "^7.1.5",
     "jss-preset-default": "^2.0.0",
     "jss-theme-reactor": "^0.11.1",
-    "marked": "^0.3.7",
+    "marked": "^0.3.12",
     "mkdirp-promise": "^5.0.1",
     "prop-types": "^15.5.10",
     "ramda": "^0.25.0",


### PR DESCRIPTION
This updates `cyverse-ui` to use 0.3.12 and higher of `marked`. 

This would be a version increase as a patch, from 1.1.0 to 1.1.1. 

This required publishing to npm.
  