### PR TITLE
Problem: Style Guide has dependency, `marked`,  known vulnerability 

### DIFF
--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cyverse-ui-guide",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5963,9 +5963,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
     },
     "material-ui": {
       "version": "0.19.4",

--- a/guide/package.json
+++ b/guide/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cyverse-ui-guide",
-  "version": "1.0.0",
-  "description": "A consumer of Troposphere's UI",
+  "version": "1.0.1",
+  "description": "A consumer of CyVerse-UI component library",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cyverse/cyverse-ui.git"
@@ -25,7 +25,7 @@
   "dependencies": {
     "babel-polyfill": "^6.23.0",
     "highlight.js": "^9.12.0",
-    "marked": "^0.3.6",
+    "marked": "^0.3.12",
     "material-ui": "^0.19.4",
     "normalize.css": "^4.1.1",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
This relates to work in #88 (but could be merged independently). 

This updates the Style Guide to use 0.3.12 and higher of `marked`.
