### PR TITLE
Problem: errors in Style Guide might not be noticed

### DIFF
--- a/guide/index.js
+++ b/guide/index.js
@@ -12,8 +12,12 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();
 
+import { setup } from './setup';
+
 import cyverseTheme from 'cyverse-ui/styles/cyverseTheme';
 import StyleGuide from './src/StyleGuide.js';
+
+setup();
 
 let newTheme = getMuiTheme(cyverseTheme);
 const App = () => (

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -8052,6 +8052,11 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
+    "raven-js": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.21.0.tgz",
+      "integrity": "sha512-6/DICF3ndYy1mxli88NG1wVtwGnzyalZZVNf/qQeiCDpNKJIyY5bsGZ2GAGcUE+nWg+9G3tQ1KL/UbG4U6vNBA=="
+    },
     "raw-body": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",

--- a/guide/package.json
+++ b/guide/package.json
@@ -31,6 +31,7 @@
     "prop-types": "^15.5.10",
     "ramda": "^0.23.0",
     "randomcolor": "^0.4.4",
+    "raven-js": "^3.21.0",
     "react": "^16.0.0",
     "react-docgen": "^2.18.0",
     "react-dom": "^16.0.0",

--- a/guide/setup.js
+++ b/guide/setup.js
@@ -1,0 +1,20 @@
+import Raven from "raven-js";
+
+const setup = () => {
+    let { hostname } = window.location;
+
+    if (hostname !== 'localhost') {
+        let dsn = 'https://13620d03f39e4d54998a51e4598d5c7a@sentry.io/269077';
+        Raven
+            .config(dsn)
+            .install();
+    }
+
+    if (!Raven.isSetup()) {
+        // eslint-disable-next-line no-console
+        console.info(
+            '[cyverse-ui] Sentry Raven client (error reporting) is not installed');
+    }
+}
+
+export { setup }


### PR DESCRIPTION
This work includes Sentry's error reporting client, `raven-js`, within the CyVerse-UI Style Guide. 

The Raven client will only be installed when the application bundle is running on a non-"localhost" domain. 

