### PR TITLE
Problem: "build/" output folder is not being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 node_modules
 lib
 es


### PR DESCRIPTION
This work excludes via `.gitignore` the `./build` folder until the repository root. 