### PR TITLE
Problem: no command for running prettier explicitly included

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
     "printWidth": 70,
-    "tabWidth": 4
+    "tabWidth": 4,
+    "trailingComma": "es5",
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3615,6 +3615,12 @@
       "dev": true,
       "optional": true
     },
+    "prettier": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
+      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+      "dev": true
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build:cjs": "BABEL_ENV=cjs babel src --out-dir lib",
     "build:es": "BABEL_ENV=es babel src --out-dir es",
     "clean": "rimraf lib && rimraf es",
+    "format": "prettier --config .prettierrc --write $(git ls-files src/*js)",
     "lint": "eslint -c .eslintrc --ext .jsx,.js --no-eslintrc src",
     "prepublish": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^2.13.*",
     "eslint-plugin-react": "^5.1.1",
     "material-ui": "~0.19.4",
+    "prettier": "1.10.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-docgen": "^2.17.0",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "material-ui": "~0.19.4",
     "prettier": "1.10.2",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0",
     "react-docgen": "^2.17.0",
+    "react-dom": "^16.0.0",
     "react-tap-event-plugin": "^3.0.1",
     "rimraf": "^2.6.2",
     "write-json": "^1.0.1"


### PR DESCRIPTION
This is offered as a resolution to #92. 

ℹ️ Small commits were used in the making of this pull request. I understand if the maintainer wishes to squash them if the work is approved. 

<details>

## Why is `prettier` pinned within `package.json`?

The Prettier documentation _recommends_ that you *pin* to an exact version of the module:

> We recommend pinning an exact version of prettier in your package.json as we introduce stylistic changes in patch releases.

source: https://prettier.io/docs/en/install.html

I want to include this for clarity since I failed to mention it within the commit message.

</details>
