### PR TITLE
WIP: Create Collapsible components and collapse code examples by default in guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 node_modules
 lib
 es

--- a/guide/src/componentDocs/Collapsible/CollapsibleCustomEx.js
+++ b/guide/src/componentDocs/Collapsible/CollapsibleCustomEx.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { Collapsible, Element, P } from "cyverse-ui";
+import { pad, marg } from "cyverse-ui/styles";
+import { Paper, RaisedButton } from "material-ui";
+
+const CollapsibleCustomEx = props => (
+    <Collapsible
+        render={({ isOpen, onToggleOpen }) => (
+            <Element whiteSpace={{ mb: 4 }}>
+                <RaisedButton
+                    primary
+                    label={`${isOpen ? "hide" : "show"} the goods`}
+                    onTouchTap={onToggleOpen}
+                />
+                <Element whiteSpace={{ mt: 4 }} hide={!isOpen}>
+                    <P>
+                        Bacon ipsum dolor amet burgdoggen tri-tip
+                        pancetta shankle chuck leberkas. Turkey swine
+                        filet mignon short ribs tongue ribeye bresaola
+                        pork tenderloin. Meatball jerky bresaola
+                        fatback pork belly chicken pork chop boudin
+                        sausage frankfurter. Bacon tri-tip shank
+                        biltong frankfurter t-bone turkey. Ribeye
+                        shankle meatball chicken, cupim corned beef
+                        tongue doner kevin leberkas sirloin. Biltong
+                        turducken shoulder chuck picanha. Brisket
+                        doner prosciutto venison turkey, short ribs
+                        corned beef pancetta pork loin alcatra
+                        leberkas shank sausage ribeye hamburger.
+                    </P>
+                </Element>
+            </Element>
+        )}
+    />
+);
+
+export default CollapsibleCustomEx;

--- a/guide/src/componentDocs/Collapsible/CollapsibleDoc.js
+++ b/guide/src/componentDocs/Collapsible/CollapsibleDoc.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { P } from 'cyverse-ui';
+import { Figure, ComponentDoc, CodeBlock } from '../../components';
+
+import CollapsibleEx from './CollapsibleEx';
+import CollapsibleExCode from '!raw-loader!./CollapsibleEx';
+import CollapsibleCustomEx from './CollapsibleCustomEx';
+import CollapsibleCustomExCode from '!raw-loader!./CollapsibleCustomEx';
+import { parse } from 'react-docgen';
+import Collapsible from '!raw-loader!cyverse-ui/Collapsible';
+const meta = parse(Collapsible);
+
+class CollapsibleDoc extends React.Component {
+    render() {
+        return (
+            <ComponentDoc meta={ meta } >
+                <Figure caption={ 'Collapsible Example' } >
+                    <CollapsibleEx/>
+                    <CodeBlock text={ CollapsibleExCode } />
+                </Figure>
+                <Figure caption={ 'Collapsible Custom Example' } >
+                    <CollapsibleCustomEx/>
+                    <CodeBlock text={ CollapsibleCustomExCode } />
+                </Figure>
+            </ComponentDoc>
+        )
+    }
+}
+
+export default CollapsibleDoc;

--- a/guide/src/componentDocs/Collapsible/CollapsibleEx.js
+++ b/guide/src/componentDocs/Collapsible/CollapsibleEx.js
@@ -1,0 +1,47 @@
+import React from "react";
+import {
+    Collapsible,
+    CollapsibleSummary,
+    CollapsibleDetail,
+    P
+} from "cyverse-ui";
+import { pad, marg } from "cyverse-ui/styles";
+import Paper from "material-ui/Paper";
+
+const CollapsibleEx = props => (
+    <Collapsible
+        render={({ isOpen, onToggleOpen }) => (
+            <Paper
+                style={{
+                    ...marg({ mb: 4 })
+                }}
+            >
+                <CollapsibleSummary
+                    onToggleOpen={onToggleOpen}
+                    isOpen={isOpen}
+                >
+                    I like bacon
+                </CollapsibleSummary>
+                <CollapsibleDetail isOpen={isOpen}>
+                    <P>
+                        Bacon ipsum dolor amet burgdoggen tri-tip
+                        pancetta shankle chuck leberkas. Turkey swine
+                        filet mignon short ribs tongue ribeye bresaola
+                        pork tenderloin. Meatball jerky bresaola
+                        fatback pork belly chicken pork chop boudin
+                        sausage frankfurter. Bacon tri-tip shank
+                        biltong frankfurter t-bone turkey. Ribeye
+                        shankle meatball chicken, cupim corned beef
+                        tongue doner kevin leberkas sirloin. Biltong
+                        turducken shoulder chuck picanha. Brisket
+                        doner prosciutto venison turkey, short ribs
+                        corned beef pancetta pork loin alcatra
+                        leberkas shank sausage ribeye hamburger.
+                    </P>
+                </CollapsibleDetail>
+            </Paper>
+        )}
+    />
+);
+
+export default CollapsibleEx;

--- a/guide/src/componentDocs/CollapsibleDetail/CollapsibleDetailDoc.js
+++ b/guide/src/componentDocs/CollapsibleDetail/CollapsibleDetailDoc.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { P } from 'cyverse-ui';
+import { Figure, ComponentDoc, CodeBlock } from '../../components';
+
+import CollapsibleDetailEx from './CollapsibleDetailEx';
+import CollapsibleDetailExCode from '!raw-loader!./CollapsibleDetailEx';
+import { parse } from 'react-docgen';
+import CollapsibleDetail from '!raw-loader!cyverse-ui/CollapsibleDetail';
+const meta = parse(CollapsibleDetail);
+
+class CollapsibleDetailDoc extends React.Component {
+    render() {
+        return (
+            <ComponentDoc meta={ meta } >
+                <Figure caption={ 'CollapsibleDetail Example' } >
+                    <CollapsibleDetailEx/>
+                    <CodeBlock text={ CollapsibleDetailExCode } />
+                </Figure>
+            </ComponentDoc>
+        )
+    }
+}
+
+export default CollapsibleDetailDoc;

--- a/guide/src/componentDocs/CollapsibleDetail/CollapsibleDetailEx.js
+++ b/guide/src/componentDocs/CollapsibleDetail/CollapsibleDetailEx.js
@@ -1,0 +1,48 @@
+import React from "react";
+import {
+    CollapsibleDetail,
+    Collapsible,
+    CollapsibleSummary,
+    P
+} from "cyverse-ui";
+import { pad, marg } from "cyverse-ui/styles";
+import Paper from "material-ui/Paper";
+
+const CollapsibleDetailEx = props => (
+    <Collapsible
+        initOpen
+        render={({ isOpen, onToggleOpen }) => (
+            <Paper
+                style={{
+                    ...marg({ mb: 4 })
+                }}
+            >
+                <CollapsibleSummary
+                    onToggleOpen={onToggleOpen}
+                    isOpen={isOpen}
+                >
+                    The world is round
+                </CollapsibleSummary>
+                <CollapsibleDetail style={{ border: "solid 1px red" }}isOpen={isOpen}>
+                    <P>
+                        Bacon ipsum dolor amet burgdoggen tri-tip
+                        pancetta shankle chuck leberkas. Turkey swine
+                        filet mignon short ribs tongue ribeye bresaola
+                        pork tenderloin. Meatball jerky bresaola
+                        fatback pork belly chicken pork chop boudin
+                        sausage frankfurter. Bacon tri-tip shank
+                        biltong frankfurter t-bone turkey. Ribeye
+                        shankle meatball chicken, cupim corned beef
+                        tongue doner kevin leberkas sirloin. Biltong
+                        turducken shoulder chuck picanha. Brisket
+                        doner prosciutto venison turkey, short ribs
+                        corned beef pancetta pork loin alcatra
+                        leberkas shank sausage ribeye hamburger.
+                    </P>
+                </CollapsibleDetail>
+            </Paper>
+        )}
+    />
+);
+
+export default CollapsibleDetailEx;

--- a/guide/src/componentDocs/CollapsibleSummary/CollapsibleSummaryDoc.js
+++ b/guide/src/componentDocs/CollapsibleSummary/CollapsibleSummaryDoc.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { P } from 'cyverse-ui';
+import { Figure, ComponentDoc, CodeBlock } from '../../components';
+
+import CollapsibleSummaryEx from './CollapsibleSummaryEx';
+import CollapsibleSummaryExCode from '!raw-loader!./CollapsibleSummaryEx';
+import { parse } from 'react-docgen';
+import CollapsibleSummary from '!raw-loader!cyverse-ui/CollapsibleSummary';
+const meta = parse(CollapsibleSummary);
+
+class CollapsibleSummaryDoc extends React.Component {
+    render() {
+        return (
+            <ComponentDoc meta={ meta } >
+                <Figure caption={ 'CollapsibleSummary Example' } >
+                    <CollapsibleSummaryEx/>
+                    <CodeBlock text={ CollapsibleSummaryExCode } />
+                </Figure>
+            </ComponentDoc>
+        )
+    }
+}
+
+export default CollapsibleSummaryDoc;

--- a/guide/src/componentDocs/CollapsibleSummary/CollapsibleSummaryEx.js
+++ b/guide/src/componentDocs/CollapsibleSummary/CollapsibleSummaryEx.js
@@ -1,0 +1,49 @@
+import React from "react";
+import {
+    CollapsibleDetail,
+    Collapsible,
+    CollapsibleSummary,
+    P
+} from "cyverse-ui";
+import { pad, marg } from "cyverse-ui/styles";
+import Paper from "material-ui/Paper";
+
+const CollapsibleSummaryEx = props => (
+    <Collapsible
+        initOpen
+        render={({ isOpen, onToggleOpen }) => (
+            <Paper
+                style={{
+                    ...marg({ mb: 4 })
+                }}
+            >
+                <CollapsibleSummary
+                    style={{ border: "solid 1px red" }}
+                    onToggleOpen={onToggleOpen}
+                    isOpen={isOpen}
+                >
+                    The world is round
+                </CollapsibleSummary>
+                <CollapsibleDetail isOpen={isOpen}>
+                    <P>
+                        Bacon ipsum dolor amet burgdoggen tri-tip
+                        pancetta shankle chuck leberkas. Turkey swine
+                        filet mignon short ribs tongue ribeye bresaola
+                        pork tenderloin. Meatball jerky bresaola
+                        fatback pork belly chicken pork chop boudin
+                        sausage frankfurter. Bacon tri-tip shank
+                        biltong frankfurter t-bone turkey. Ribeye
+                        shankle meatball chicken, cupim corned beef
+                        tongue doner kevin leberkas sirloin. Biltong
+                        turducken shoulder chuck picanha. Brisket
+                        doner prosciutto venison turkey, short ribs
+                        corned beef pancetta pork loin alcatra
+                        leberkas shank sausage ribeye hamburger.
+                    </P>
+                </CollapsibleDetail>
+            </Paper>
+        )}
+    />
+);
+
+export default CollapsibleSummaryEx;

--- a/guide/src/componentDocs/index.js
+++ b/guide/src/componentDocs/index.js
@@ -25,3 +25,6 @@ export { default as CheckableAvatarDoc } from './CheckableAvatar/CheckableAvatar
 export { default as SummaryTextDoc } from './SummaryText/SummaryTextDoc';
 export { default as ElementDoc } from './Element/ElementDoc';
 export { default as BarGraphDoc } from './BarGraph/BarGraphDoc';
+export { default as CollapsibleDoc } from './Collapsible/CollapsibleDoc';
+export { default as CollapsibleSummaryDoc } from './CollapsibleSummary/CollapsibleSummaryDoc';
+export { default as CollapsibleDetailDoc } from './CollapsibleDetail/CollapsibleDetailDoc';

--- a/guide/src/components/CodeBlock.js
+++ b/guide/src/components/CodeBlock.js
@@ -1,24 +1,26 @@
-import React, {Component} from 'react';
-import PropTypes from 'prop-types';
-import marked from 'marked';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import marked from "marked";
+import { FlatButton } from "material-ui";
+import CodeIcon from "material-ui/svg-icons/action/code";
+import { Collapsible, Element } from "cyverse-ui";
 
 const styles = {
     root: {
         marginTop: 20,
         marginBottom: 20,
-        padding: '0 10px',
-    },
+        padding: "0"
+    }
 };
 
 class CodeBlock extends Component {
-
     static propTypes = {
         style: PropTypes.object,
-        text: PropTypes.string.isRequired,
+        text: PropTypes.string.isRequired
     };
 
     static defaultProps = {
-        text: '',
+        text: ""
     };
 
     componentWillMount() {
@@ -30,31 +32,41 @@ class CodeBlock extends Component {
             sanitize: false,
             smartLists: true,
             smartypants: false,
-            language: 'jsx',
-            highlight: (code, lang) => (
-                require('highlight.js').highlight(lang, code).value
-            ),
+            language: "jsx",
+            highlight: (code, lang) =>
+                require("highlight.js").highlight(lang, code).value
         });
     }
 
     render() {
-        const {
-            style,
-            text,
-        } = this.props;
+        const { style, text } = this.props;
 
-        const renderCode = (
-`\`\`\`jsx
+        const renderCode = `\`\`\`jsx
 ${text}
-\`\`\``
-        );
+\`\`\``;
 
         /* eslint-disable react/no-danger */
         return (
-            <div
-                style={{ ...styles.root, ...style}}
-                className="markdown-body"
-                dangerouslySetInnerHTML={{__html: marked(renderCode)}}
+            <Collapsible
+                render={({ isOpen, onToggleOpen }) => (
+                    <Element {...this.props}>
+                        <FlatButton
+                            style={{ width: "100%" }}
+                            label={`${isOpen ? "Hide" : "Show"} Code`}
+                            onTouchTap={onToggleOpen}
+                            icon={<CodeIcon />}
+                        />
+                        <Element hide={!isOpen}>
+                            <div
+                                style={{ ...styles.root, ...style }}
+                                className="markdown-body"
+                                dangerouslySetInnerHTML={{
+                                    __html: marked(renderCode)
+                                }}
+                            />
+                        </Element>
+                    </Element>
+                )}
             />
         );
         /* eslint-enable */

--- a/guide/src/components/Figure.js
+++ b/guide/src/components/Figure.js
@@ -1,39 +1,40 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import theme from '../theme';
-import { styles } from 'cyverse-ui/styles';
-import { Title } from 'cyverse-ui';
+import React from "react";
+import PropTypes from "prop-types";
+import theme from "../theme";
+import { styles } from "cyverse-ui/styles";
+import { Title, Element } from "cyverse-ui";
 
 class Figure extends React.Component {
     render() {
         return (
-            <figure style={{
-                    margin: "0px",
-                    border: "solid 1px lightgrey",
-                    padding: "10px",
-                }}
-            >
-                <figcaption style={{
-                        ...styles.t.title,
-                        background: theme.color.primary,
-                        color: "white",
-                        padding: "10px",
-                        margin: "-11px -11px 20px",
-                    }}
+            <Element tag="figure" whiteSpace={{ m: 0, mb: 3 }}>
+                <Element
+                    tag="figcaption"
+                    typography="title"
+                    color="white"
+                    background="primary1Color"
+                    whiteSpace={{ p: 2 }}
                 >
-                    <Title title m={ 0 }>
-                        { this.props.caption }
+                    <Title title m={0}>
+                        {this.props.caption}
                     </Title>
-                </figcaption>
-                { this.props.children }
-            </figure>
-
+                </Element>
+                <Element
+                    style={{
+                        border: "solid 1px lightgrey",
+                        borderTop: "none"
+                    }}
+                    whiteSpace={{ p: 3 }}
+                >
+                    {this.props.children}
+                </Element>
+            </Element>
         );
     }
 }
 
 Figure.propTypes = {
-    className: PropTypes.string,
+    className: PropTypes.string
 };
 
 export default Figure;

--- a/src/Collapsible.js
+++ b/src/Collapsible.js
@@ -1,0 +1,36 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+/**
+ * Collapsible is a state machine for building collapsible components.
+ *
+ * It uses the [render prop pattern](https://cdb.reacttraining.com/use-a-render-prop-50de598f11ce) and makes no assumptions about your structure by returning what you pass as a render function with the props object to manage your component's state passed as the single argument.
+ * One can either use `CollapsibleSummary` and `CollapsibleDetail` to build a quick collapsible component or pass anything you want to build custom collapsible components.
+ **/
+class Collapsible extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isOpen: props.initOpen ? true : false
+        };
+    }
+
+    onToggleOpen = () =>
+        this.setState({ isOpen: !this.state.isOpen });
+
+    render() {
+        const { render } = this.props;
+        const { isOpen } = this.state;
+        return render({ isOpen, onToggleOpen: this.onToggleOpen });
+    }
+}
+
+Collapsible.displayName = "Collapsible";
+
+Collapsible.propTypes = {
+    /**
+     * Expects a render function that returns what you want Collapsible to control. The props `onToggleOpen` and  `isOpen` will be passed as an object to your render function
+     */
+    render: PropTypes.func.isRequired
+};
+
+export default Collapsible;

--- a/src/CollapsibleDetail.js
+++ b/src/CollapsibleDetail.js
@@ -1,0 +1,46 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { createStyleSheet } from "jss-theme-reactor";
+import getStyleManager from "./styles/getStyleManager";
+import Element from "./Element";
+import Hr from "./Hr";
+
+// Define static styles here.
+// Each key of the returned object will be available as a className below.
+const styleSheet = () =>
+    createStyleSheet("CollapsibleDetail", theme => ({
+        wrapper: {}
+    }));
+/**
+ * CollapsibleDetail is used to build a collapsible component. It is the body or detail of your content. Typically the user clicks or taps CollapsibleSummary to show or hide CollapsibleDetail.
+ */
+const CollapsibleDetail = ({ children, isOpen, ...rest }) => {
+    // Generate classes object and render corresponding style definitions in header.
+    const classes = getStyleManager({}).render(styleSheet());
+
+    return (
+        <Element {...rest} hide={!isOpen}>
+            <Hr m={0} />
+            <Element
+                className={classes.wrapper}
+                whiteSpace={{ p: 3 }}
+            >
+                {children}
+            </Element>
+        </Element>
+    );
+};
+CollapsibleDetail.displayName = "CollapsibleDetail";
+
+CollapsibleDetail.propTypes = {
+    /**
+     * The content to show in the body. Can be any component or element you wish.
+     */
+    children: PropTypes.node,
+    /**
+     * The open close state of your collapsible component. Controls whether the detail is hidden or not.
+     */
+    isOpen: PropTypes.bool
+};
+
+export default CollapsibleDetail;

--- a/src/CollapsibleSummary.js
+++ b/src/CollapsibleSummary.js
@@ -1,0 +1,70 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { createStyleSheet } from "jss-theme-reactor";
+import getStyleManager from "./styles/getStyleManager";
+import ToggleArrowIcon from "material-ui/svg-icons/hardware/keyboard-arrow-down";
+
+import Element from "./Element";
+
+// Define static styles here.
+// Each key of the returned object will be available as a className below.
+const styleSheet = () =>
+    createStyleSheet("CollapsibleSummary", theme => ({
+        wrapper: {
+            cursor: "pointer",
+            alignItems: "center",
+            justifyContent: "space-between"
+        },
+        ToggleArrowIcon__open: {
+            transform: "rotate(180deg)"
+        }
+    }));
+/**
+ * CollapsibleSummary is used to build a Collapsible component. It is the summary or title of your content. Typically the user clicks or taps CollapsibleSummary to show or hide CollapsibleDetail.
+ */
+const CollapsibleSummary = ({
+    isOpen,
+    onToggleOpen,
+    children,
+    ...rest
+}) => {
+    // Generate classes object and render corresponding style definitions in header.
+    const classes = getStyleManager({}).render(styleSheet());
+
+    return (
+        <Element
+            {...rest}
+            onClick={onToggleOpen}
+            className={classes.wrapper}
+            display="flex"
+            whiteSpace={{ p: 3 }}
+            typography="body2"
+        >
+            {children}
+            <ToggleArrowIcon
+                className={
+                    isOpen ? classes.ToggleArrowIcon__open : null
+                }
+                style={{ width: "30px", height: "30px" }}
+            />
+        </Element>
+    );
+};
+CollapsibleSummary.displayName = "CollapsibleSummary";
+
+CollapsibleSummary.propTypes = {
+    /**
+     * The summary or title. Can be any component or element you wish but works best as a string
+     */
+    children: PropTypes.node,
+    /**
+     * The callback you wish to toggle open close state.
+     */
+    onToggleOpen: PropTypes.func,
+    /**
+     * The open close state of your collapsible component. Controls the direction of the open close icon.
+     */
+    isOpen: PropTypes.bool
+};
+
+export default CollapsibleSummary;

--- a/src/index.js
+++ b/src/index.js
@@ -31,3 +31,6 @@ export { default as MDBlock } from './MDBlock';
 export { default as SummaryText } from './SummaryText';
 export { default as Element } from './Element';
 export { default as BarGraph } from './BarGraph';
+export { default as Collapsible } from './Collapsible';
+export { default as CollapsibleSummary } from './CollapsibleSummary';
+export { default as CollapsibleDetail } from './CollapsibleDetail';

--- a/src/styles/marg.js
+++ b/src/styles/marg.js
@@ -1,8 +1,8 @@
-import { variables as styleVars } from '../styles';
+import { variables as styleVars } from "../styles";
 
 const sizes = styleVars.l.margSizes;
 
-const marg = ( props ) => {
+const marg = props => {
     //
     // For more information on how to use this style util
     // see cyverse-ui/src/style/README.md
@@ -14,32 +14,31 @@ const marg = ( props ) => {
             margin = metric === 0 ? 0 : sizes[metric - 1];
         }
         switch (rule) {
-                case "mt":
-                    style.marginTop = margin;
-                    break;
-                case "mr":
-                    style.marginRight = margin;
-                    break;
-                case "mb":
-                    style.marginBottom = margin;
-                    break;
-                case "ml":
-                    style.marginLeft = margin;
-                    break;
-                case "ms":
-                    style.marginRight = style.marginLeft = margin;
-                    break;
-                case "mv":
-                    style.marginTop = style.marginBottom = margin;
-                    break;
-                case "m":
-                    style.marginTop = style.marginRight = style.marginBottom = style.marginLeft = margin;
-                    break;
-            }
+            case "m":
+                style.marginTop = style.marginRight = style.marginBottom = style.marginLeft = margin;
+                break;
+            case "mt":
+                style.marginTop = margin;
+                break;
+            case "mr":
+                style.marginRight = margin;
+                break;
+            case "mb":
+                style.marginBottom = margin;
+                break;
+            case "ml":
+                style.marginLeft = margin;
+                break;
+            case "ms":
+                style.marginRight = style.marginLeft = margin;
+                break;
+            case "mv":
+                style.marginTop = style.marginBottom = margin;
+                break;
+        }
 
         return style;
-
     }, {});
-}
+};
 
 export default marg;

--- a/src/styles/pad.js
+++ b/src/styles/pad.js
@@ -18,8 +18,13 @@ const Pad = ( props ) => {
                     ? sizes[value - 1]
                     : value
                 break;
+            case "pt":
+                style.paddingTop = typeof value == "number"
+                    ? sizes[value - 1]
+                    : value
+                break
             case "pb":
-                style.paddingnBottom = typeof value == "number"
+                style.paddingBottom = typeof value == "number"
                     ? sizes[value - 1]
                     : value
                 break;


### PR DESCRIPTION
Introduces a Collapsible component that acts like a state machine specifically for managing the toggled state of a collapsible component. (Maybe only useful to me internally)

Uses Collapsible to hide the code examples in the guide by default.

In addition, CollapsibleSummary and CollapsibleDetail components were made for making a simple accordion-esqu thing.

Next steps would be to animate CollapsibleDetail's height in transition.
 
<img width="1119" alt="screen shot 2018-01-18 at 1 36 03 pm" src="https://user-images.githubusercontent.com/7366338/35120224-a49dbe88-fc54-11e7-8ce3-15999ddaf06f.png">
<img width="1108" alt="screen shot 2018-01-18 at 1 35 40 pm" src="https://user-images.githubusercontent.com/7366338/35120225-a4b7ab0e-fc54-11e7-883c-e81e832c9583.png">
<img width="1163" alt="screen shot 2018-01-18 at 1 35 19 pm" src="https://user-images.githubusercontent.com/7366338/35120223-a4833464-fc54-11e7-8579-6578100735ff.png">
