### PR TITLE
Remove dynamic style from Element

### DIFF
--- a/src/BarGraph.js
+++ b/src/BarGraph.js
@@ -9,7 +9,7 @@ const styles = theme => ({
     wrapper: {
         display: "flex",
         background: "rgba(0,0,0,.08)",
-        height: ({ compact }) => (compact ? "8px" : "14px"),
+        height: "8px",
     },
     barBefore: {
         transition: "flex-basis ease .3s",

--- a/src/Element.js
+++ b/src/Element.js
@@ -7,8 +7,6 @@ import injectSheet, { withTheme } from "react-jss";
 import * as events from "./utils/events";
 
 // Each key of the returned styles object will be available as a className below.
-const getColor = (palette, background) =>
-    palette[background] || background;
 const styles = theme => ({
     ...R.mergeAll(R.toPairs(theme.palette).map( color => (
         { ["background_" + color[0]]: { background: color[1] } }

--- a/src/Element.js
+++ b/src/Element.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import filterDomProps from "filter-react-dom-props";
+import * as R from "ramda";
 import classnames from "classnames";
 import injectSheet, { withTheme } from "react-jss";
 import * as events from "./utils/events";
@@ -9,11 +10,12 @@ import * as events from "./utils/events";
 const getColor = (palette, background) =>
     palette[background] || background;
 const styles = theme => ({
-    wrapper: {
-        background: props =>
-            getColor(theme.palette, props.background),
-        color: props => getColor(theme.palette, props.color),
-    },
+    ...R.mergeAll(R.toPairs(theme.palette).map( color => (
+        { ["background_" + color[0]]: { background: color[1] } }
+    ))),
+    ...R.mergeAll(R.toPairs(theme.palette).map( color => (
+        { ["color_" + color[0]]: { color: color[1] } }
+    ))),
     ...theme.utility,
     ...theme.typography,
     ...theme.whitespace,
@@ -46,6 +48,7 @@ class Element extends React.Component {
             classes,
             hide = false,
             hideReadable = false,
+            themeBackground,
             typography = "body1",
             whitespace = [],
             elevation = 0,
@@ -72,6 +75,7 @@ class Element extends React.Component {
             { [classes.hide]: hide },
             { [classes.hideReadable]: hideReadable },
             { [elevationClass]: elevation > 0 },
+            { [classes["background_" + themeBackground]]: themeBackground },
             classes.wrapper,
             classes[typography],
             whitespaceClass


### PR DESCRIPTION
Element was using a dynamic style for the background property that allowed users to set the background through a prop. This was to expose theme colors as a value that could be passed. This caused a major performance hit as every Element component on the page rendered its own styles to the header. Large lists of 200 or more would be very slow to load.

Another issue was  that simply exposing a Background prop begged the question what other css values can I set.

Now the prop is called "themeBackground" and only sets colors from the theme as static assignments. This means that only one style is rendered for all Element components regardless of how many. Also, it no longer duplicates the CSS interface. 