### PR TITLE
Add Element prop documentation

### DIFF
--- a/guide/src/componentDocs/Element/ElementEx.js
+++ b/guide/src/componentDocs/Element/ElementEx.js
@@ -42,6 +42,15 @@ const ElementEx = props => (
             elevation={2}
             children="You get the idea. Use the source!"
         />
+         <Element
+            hide={true}
+            children="I'm hidden from everything"
+        />
+        <Element
+            hideReadable={true}
+            children="Screen readers and search engines can see me but you can't"
+        />
+
     </Element>
 );
 

--- a/src/Element.js
+++ b/src/Element.js
@@ -88,6 +88,14 @@ Element.propTypes = {
      */
     root: PropTypes.string,
     /**
+     * Hides Element from the DOM using `display: none`.
+     */
+    hide: PropTypes.bool,
+    /**
+     * Hides Element visually but is still visible to screen readers. Good for binding semantic interfaces to non semantic interfaces. Eg: binding a check box to some divs that are made to look like a toggle button.
+     */
+    hideReadable: PropTypes.bool,
+    /**
      * The typography styles from the theme like "title" or "body1"
      */
     typography: PropTypes.string,
@@ -106,6 +114,8 @@ Element.propTypes = {
 
 Element.defaultProps = {
     root: "div",
+    hide: false,
+    hideReadable: false,
     typography: "body1",
     whitespace: ["m0", "p0"],
 };

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -19,8 +19,12 @@ const styles = {
     },
     utility: {
         hideReadable: {
-            position: "fixed",
-            top: "9999px",
+            position: "absolute",
+            left: "-10000px",
+            top: "auto",
+            width: "1px",
+            height: "1px",
+            overflow: "hidden",
         },
         hide: {
             display: "none !important",


### PR DESCRIPTION
Adds documentation on `Element` props `hide` and `hideReadable`.
Improves styling for hideReadable to work for a broader rage of readers and crawlers.