### PR TITLE
Rename MediaCard props to match MUI

### DIFF
--- a/guide/src/componentDocs/MediaCard/MediaCardEx.js
+++ b/guide/src/componentDocs/MediaCard/MediaCardEx.js
@@ -68,8 +68,8 @@ export default class extends React.Component {
                                     children={item.name[0]}
                                 />
                             }
-                            title={item.name}
-                            subTitle={item.tagline}
+                            primaryText={item.name}
+                            secondaryText={item.tagline}
                             summary={
                                 <SummaryText
                                     children={item.description}

--- a/src/MediaCard.js
+++ b/src/MediaCard.js
@@ -23,13 +23,13 @@ class MediaCard extends React.Component {
          */
         image: PropTypes.element,
         /**
-         * The identity of the MediaCard
+         * The primary text on the Identity of the MediaCard.
          */
-        title: PropTypes.node,
+        primaryText: PropTypes.node,
         /**
-         * Sub-information like creation date or caption
+         * The secondary text on the Identity of the MediaCard for sub-information like the creation date.
          */
-        subTitle: PropTypes.node,
+        secondaryText: PropTypes.node,
         /**
          * Additional meta or status info
          */
@@ -112,9 +112,9 @@ class MediaCard extends React.Component {
     render() {
         const {
             className,
-            title,
+            primaryText,
             avatar,
-            subTitle,
+            secondaryText,
             summary,
             detail,
             isExpanded,
@@ -159,8 +159,8 @@ class MediaCard extends React.Component {
                                     }}
                                 />
                              }
-                            primaryText = { title }
-                            secondaryText = { subTitle }
+                            primaryText = { primaryText }
+                            secondaryText = { secondaryText }
                         />
                     </ListCardIdentity>
 


### PR DESCRIPTION
MediaCard passes props `title` and `subTitle` down to the Identity component.

These props although make sense in the context of the MediaCard should be consistent with Identity's props which are consistent with Material-UI's props.
 
#79 also points out a typo of sorts that `subTitle` should be `subtitle`.

This PR changes these props for consistency with Identity and Material-UI.